### PR TITLE
Corrected a mistake in mov special reg instruction

### DIFF
--- a/MOVRS.htm
+++ b/MOVRS.htm
@@ -78,7 +78,7 @@ The instructions must be executed at privilege level 0 or in real-address
 mode; otherwise, a protection exception will be raised.
 <P>
 The reg field within the ModRM byte specifies which of the special
-registers in each category is involved. The two bits in the  field are
+registers in each category is involved. The two bits in the mod field are
 always 11. The r/m field specifies the general register involved.
 <P>
 <HR>


### PR DESCRIPTION
Added the missing word "mod" to the instruction related to move to/from special register instruction