### PR TITLE
Fix typo in 16-bit MOD R/M table

### DIFF
--- a/s17_02.htm
+++ b/s17_02.htm
@@ -194,8 +194,8 @@ disp16               110   06    0E    16    1E    26    2E    36    3E
 
 [BX+SI]+disp16       000   80    88    90    98    A0    A8    B0    B8
 [BX+DI]+disp16       001   81    89    91    99    A1    A9    B1    B9
-[BX+SI]+disp16       010   82    8A    92    9A    A2    AA    B2    BA
-[BX+DI]+disp16       011   83    8B    93    9B    A3    AB    B3    BB
+[BP+SI]+disp16       010   82    8A    92    9A    A2    AA    B2    BA
+[BP+DI]+disp16       011   83    8B    93    9B    A3    AB    B3    BB
 [SI]+disp16      10  100   84    8C    94    9C    A4    AC    B4    BC
 [DI]+disp16          101   85    8D    95    9D    A5    AD    B5    BD
 [BP]+disp16          110   86    8E    96    9E    A6    AE    B6    BE


### PR DESCRIPTION
According to intel x86 manual (Vol.2, sec. 2.1.5) the table should look like this:
![image](https://user-images.githubusercontent.com/27109464/141614610-6ced3d4a-e313-4fb7-b537-d1db6b3aa680.png)

I have update the corresponding table in the manual to match the above data