### PR TITLE
Fix various broken links

### DIFF
--- a/c02.htm
+++ b/c02.htm
@@ -33,8 +33,8 @@ The basic programming model consists of these aspects:
 Note that input/output is not included as part of the basic programming
 model. Systems designers may choose to make I/O instructions available to
 applications or may choose to reserve these functions for the operating
-system. For this reason, the I/O features of the 80386 are discussed in 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/pii.htm">Part II</A>.
+system. For this reason, the I/O features of the 80386 are discussed in
+<A HREF="PII.htm">Part II</A>.
 <P>
 This chapter contains a section for each aspect of the architecture that is
 normally visible to applications.

--- a/s02_03.htm
+++ b/s02_03.htm
@@ -13,7 +13,7 @@ Chapter 2 -- Basic Programming Model</A><BR>
 <P>
 <H1>2.3  Registers</H1>
 The 80386 contains a total of sixteen registers that are of interest to the
-applications programmer. As 
+applications programmer. As
 <A HREF="s02_03.htm#fig2-5">Figure 2-5</A>
   shows, these registers may be
 grouped into these basic categories:
@@ -36,7 +36,7 @@ contain the operands of logical and arithmetic operations. They may also be
 used interchangeably for operands of address computations (except that ESP
 cannot be used as an index operand).
 <P>
-As 
+As
 <A HREF="s02_03.htm#fig2-5">Figure 2-5</A>
   shows, the low-order word of each of these eight registers
 has a separate name and can be treated as a unit. This feature is useful for
@@ -79,7 +79,7 @@ At any given instant, six segments of memory may be immediately accessible
 to an executing 80386 program. The segment registers CS, DS, SS, ES, FS, and
 GS are used to identify these six current segments. Each of these registers
 specifies a particular kind of segment, as characterized by the associated
-mnemonics ("code," "data," or "stack") shown in 
+mnemonics ("code," "data," or "stack") shown in
 <A HREF="s02_03.htm#fig2-6">Figure 2-6</A>
   . Each register
 uniquely determines one particular segment, from among the segments that
@@ -90,8 +90,8 @@ known as the current code segment; it is specified by means of the CS
 register. The 80386 fetches all instructions from this code segment, using
 as an offset the contents of the instruction pointer. CS is changed
 implicitly as the result of intersegment control-transfer instructions (for
-example, <A HREF="CALL.htm">CALL</A> and 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/JMP.html">JMP</A>), interrupts, and exceptions.
+example, <A HREF="CALL.htm">CALL</A> and
+<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/JMP.htm">JMP</A>), interrupts, and exceptions.
 <P>
 Subroutine calls, parameters, and procedure activation records usually
 require that a region of memory be allocated for a stack. All stack
@@ -216,9 +216,9 @@ as "the" stack. SS is used automatically by the processor for all
 stack operations.
 
 <LI>The stack pointer (ESP) register. ESP points to the top of the
-push-down stack (TOS). It is referenced implicitly by <A HREF="PUSH.htm">PUSH</A> and <A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/POP.html">POP</A>
+push-down stack (TOS). It is referenced implicitly by <A HREF="PUSH.htm">PUSH</A> and <A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/POP.htm">POP</A>
 operations, subroutine calls and returns, and interrupt operations.
-When an item is pushed onto the stack (see 
+When an item is pushed onto the stack (see
 <A HREF="s02_03.htm#fig2-7">Figure 2-7</A>
   ), the processor
 decrements ESP, then writes the item at the new TOS. When an item is
@@ -238,7 +238,7 @@ stack segment (i.e., the segment currently selected by SS). Because
 SS does not have to be explicitly specified, instruction encoding in
 such cases is more efficient. EBP can also be used to index into
 segments addressable via other segment registers.
-</OL> 
+</OL>
 <P>
 <A NAME="fig2-7">
 <PRE>Figure 2-7.  80386 Stack</PRE>
@@ -263,7 +263,7 @@ segments addressable via other segment registers.
 </PRE>
 <P>
 <H2>2.3.4  Flags Register</H2>
-The flags register is a 32-bit register named EFLAGS. 
+The flags register is a 32-bit register named EFLAGS.
 <A HREF="s02_03.htm#fig2-8">Figure 2-8</A>
   defines
 the bits within this register. The flags control certain operations and
@@ -337,7 +337,7 @@ instruction to be executed. The instruction pointer is not directly visible
 to the programmer; it is controlled implicitly by control-transfer
 instructions, interrupts, and exceptions.
 <P>
-As 
+As
 <A HREF="s02_03.htm#fig2-9">Figure 2-9</A>
   shows, the low-order 16 bits of EIP is named IP and can be
 used by the processor as a unit. This feature is useful when executing

--- a/s02_05.htm
+++ b/s02_05.htm
@@ -14,7 +14,7 @@ Chapter 2 -- Basic Programming Model</A><BR>
 <H1>2.5  Operand Selection</H1>
 An instruction can act on zero or more operands, which are the data
 manipulated by the instruction. An example of a zero-operand instruction is
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/NOP.html">NOP</A> (no operation). An operand can be in any of these locations:
+<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/NOP.htm">NOP</A> (no operation). An operand can be in any of these locations:
 <UL>
 <LI> In the instruction itself (an immediate operand)
 <LI> In a register (EAX, EBX, ECX, EDX, ESI, EDI, ESP, or EBP in the case
@@ -137,38 +137,38 @@ most flexible.
 <LI>A few data-manipulation instructions implicitly use specialized
 addressing methods:
 <UL>
-<LI> For a few short forms of 
+<LI> For a few short forms of
 <A HREF="MOV.htm">MOV</A> that implicitly use the EAX register,
 the offset of the operand is coded as a doubleword in the
 instruction. No base register, index register, or scaling factor
 are used.
-<LI> String operations implicitly address memory via DS:ESI, 
+<LI> String operations implicitly address memory via DS:ESI,
 (<A HREF="MOVS.htm">MOVS</A>,
-<A HREF="CMPS.htm">CMPS</A>, 
-<A HREF="OUTS.htm">OUTS</A>, 
-<A HREF="LODS.htm">LODS</A>, 
-<A HREF="SCAS.htm">SCAS</A>) or via ES:EDI 
-(<A HREF="MOVS.htm">MOVS</A>, 
-<A HREF="CMPS.htm">CMPS</A>, 
-<A HREF="INS.htm">INS</A>, 
+<A HREF="CMPS.htm">CMPS</A>,
+<A HREF="OUTS.htm">OUTS</A>,
+<A HREF="LODS.htm">LODS</A>,
+<A HREF="SCAS.htm">SCAS</A>) or via ES:EDI
+(<A HREF="MOVS.htm">MOVS</A>,
+<A HREF="CMPS.htm">CMPS</A>,
+<A HREF="INS.htm">INS</A>,
 <A HREF="STOS.htm">STOS</A>).
 
 <LI> Stack operations implicitly address operands via SS:ESP
-registers; e.g., 
-<A HREF="PUSH.htm">PUSH</A>, 
-<A HREF="POP.htm">POP</A>, 
-<A HREF="PUSHA.htm">PUSHA</A>, 
-<A HREF="PUSHA.htm">PUSHAD</A>, 
-<A HREF="POPA.htm">POPA</A>, 
-<A HREF="POPA.htm">POPAD</A>, 
+registers; e.g.,
+<A HREF="PUSH.htm">PUSH</A>,
+<A HREF="POP.htm">POP</A>,
+<A HREF="PUSHA.htm">PUSHA</A>,
+<A HREF="PUSHA.htm">PUSHAD</A>,
+<A HREF="POPA.htm">POPA</A>,
+<A HREF="POPA.htm">POPAD</A>,
 <A HREF="PUSHF.htm">PUSHF</A>,
-<A HREF="PUSHF.htm">PUSHFD</A>, 
-<A HREF="POPF.htm">POPF</A>, 
-<A HREF="POPF.htm">POPFD</A>, 
-<A HREF="CALL.htm">CALL</A>, 
-<A HREF="RET.htm">RET</A>, 
-<A HREF="IRET.htm">IRET</A>, 
-<A HREF="IRET.htm">IRETD</A>, 
+<A HREF="PUSHF.htm">PUSHFD</A>,
+<A HREF="POPF.htm">POPF</A>,
+<A HREF="POPF.htm">POPFD</A>,
+<A HREF="CALL.htm">CALL</A>,
+<A HREF="RET.htm">RET</A>,
+<A HREF="IRET.htm">IRET</A>,
+<A HREF="IRET.htm">IRETD</A>,
 exceptions, and interrupts.
 </UL>
 </OL>

--- a/s03_02.htm
+++ b/s03_02.htm
@@ -31,14 +31,14 @@ If the integer is unsigned, CF may be tested after one of these arithmetic
 operations to determine whether the operation required a carry or borrow of
 a one-bit in the high-order position of the destination operand. CF is set
 if a one-bit was carried out of the high-order position (addition
-instructions <A HREF="ADD.htm">ADD</A>, <A HREF="ADC.htm">ADC</A>, <A HREF="AAA.htm">AAA</A>, and 
+instructions <A HREF="ADD.htm">ADD</A>, <A HREF="ADC.htm">ADC</A>, <A HREF="AAA.htm">AAA</A>, and
 <A HREF="DAA.htm">DAA</A>) or if a one-bit was carried (i.e.
-borrowed) into the high-order bit (subtraction instructions 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
+borrowed) into the high-order bit (subtraction instructions
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
 <A HREF="AAS.htm">AAS</A>,
-<A HREF="DAS.htm">DAS</A>, 
-<A HREF="CMP.htm">CMP</A>, and 
+<A HREF="DAS.htm">DAS</A>,
+<A HREF="CMP.htm">CMP</A>, and
 <A HREF="NEG.htm">NEG</A>).
 <P>
 If the integer is signed, both SF and OF should be tested. SF always has
@@ -47,113 +47,113 @@ of a signed integer is the bit next to the -- 6 of a byte, bit 14 of
 a word, or bit 30 of a doubleword. OF is set in either of these cases:
 <UL>
 <LI> A one-bit was carried out of the MSB into the sign bit but no one bit
-was carried out of the sign bit (addition instructions 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
+was carried out of the sign bit (addition instructions
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
 <A HREF="INC.htm">INC</A>,
-<A HREF="AAA.htm">AAA</A>, and 
-<A HREF="DAA.htm">DAA</A>). 
+<A HREF="AAA.htm">AAA</A>, and
+<A HREF="DAA.htm">DAA</A>).
 In other words, the result was greater than the greatest
 positive number that could be contained in the destination operand.
 <LI> A one-bit was carried from the sign bit into the MSB but no one bit
-was carried into the sign bit (subtraction instructions 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
+was carried into the sign bit (subtraction instructions
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
 <A HREF="DEC.htm">DEC</A>,
-<A HREF="AAS.htm">AAS</A>, 
-<A HREF="DAS.htm">DAS</A>, 
-<A HREF="CMP.htm">CMP</A>, and 
+<A HREF="AAS.htm">AAS</A>,
+<A HREF="DAS.htm">DAS</A>,
+<A HREF="CMP.htm">CMP</A>, and
 <A HREF="NEG.htm">NEG</A>). In other words, the result was smaller that
 the smallest negative number that could be contained in the destination
 operand.
 </UL>
 These status flags are tested by executing one of the two families of
-conditional instructions: 
-<A HREF="Jcc.htm">Jcc</A> (jump on condition cc) or 
+conditional instructions:
+<A HREF="Jcc.htm">Jcc</A> (jump on condition cc) or
 <A HREF="SETcc.htm">SETcc</A> (byte set on condition).
 
 <H2>3.2.1  Addition and Subtraction Instructions</H2>
-<A HREF="ADD.htm">ADD</A> (Add Integers) 
+<A HREF="ADD.htm">ADD</A> (Add Integers)
 replaces the destination operand with the sum of the
 source and destination operands. Sets CF if overflow.
 <P>
-<A HREF="ADC.htm">ADC</A> (Add Integers with Carry) 
+<A HREF="ADC.htm">ADC</A> (Add Integers with Carry)
 sums the operands, adds one if CF is set, and
-replaces the destination operand with the result. If CF is cleared, 
+replaces the destination operand with the result. If CF is cleared,
 <A HREF="ADC.htm">ADC</A>
-performs the same operation as the 
-<A HREF="ADD.htm">ADD</A> instruction. An 
+performs the same operation as the
+<A HREF="ADD.htm">ADD</A> instruction. An
 <A HREF="ADD.htm">ADD</A> followed by
-multiple <A HREF="ADC.htm">ADC</A> instructions can be used to add 
+multiple <A HREF="ADC.htm">ADC</A> instructions can be used to add
 numbers longer than 32 bits.
 <P>
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/INC&gt;htm">INC</A> (Increment) 
-adds one to the destination operand. 
-<A HREF="INC.htm">INC</A> does not affect CF. Use 
-<A HREF="ADD.htm">ADD</A> with an immediate value of 1 if 
+<A HREF="INC.htm">INC</A> (Increment)
+adds one to the destination operand.
+<A HREF="INC.htm">INC</A> does not affect CF. Use
+<A HREF="ADD.htm">ADD</A> with an immediate value of 1 if
 an increment that updates carry (CF) is needed.
 <P>
-<A HREF="SUB.htm">SUB</A> (Subtract Integers) 
+<A HREF="SUB.htm">SUB</A> (Subtract Integers)
 subtracts the source operand from the destination
 operand and replaces the destination operand with the result. If a borrow is
 required, the CF is set. The operands may be signed or unsigned bytes,
 words, or doublewords.
 <P>
-<A HREF="SBB.htm">SBB</A> (Subtract Integers with Borrow) 
+<A HREF="SBB.htm">SBB</A> (Subtract Integers with Borrow)
 subtracts the source operand from the
 destination operand, subtracts 1 if CF is set, and returns the result to the
-destination operand. If CF is cleared, 
+destination operand. If CF is cleared,
 <A HREF="SBB.htm">SBB</A> performs the same operation as
-<A HREF="SUB.htm">SUB</A>. <A HREF="SUB.htm">SUB</A> followed by multiple 
+<A HREF="SUB.htm">SUB</A>. <A HREF="SUB.htm">SUB</A> followed by multiple
 <A HREF="SBB.htm">SBB</A> instructions may be used to subtract
-numbers longer than 32 bits. If CF is cleared, 
-<A HREF="SBB.htm">SBB</A> performs the same operation as 
+numbers longer than 32 bits. If CF is cleared,
+<A HREF="SBB.htm">SBB</A> performs the same operation as
 <A HREF="SUB.htm">SUB</A>.
 <P>
-<A HREF="DEC.htm">DEC</A> (Decrement) 
-subtracts 1 from the destination operand. 
-<A HREF="DEC.htm">DEC</A> does not update CF. Use 
-<A HREF="SUB.htm">SUB</A> with an immediate value of 1 to perform a 
+<A HREF="DEC.htm">DEC</A> (Decrement)
+subtracts 1 from the destination operand.
+<A HREF="DEC.htm">DEC</A> does not update CF. Use
+<A HREF="SUB.htm">SUB</A> with an immediate value of 1 to perform a
 decrement that affects carry.
 
 <H2>3.2.2  Comparison and Sign Change Instruction</H2>
-<A HREF="CMP.htm">CMP</A> (Compare) 
+<A HREF="CMP.htm">CMP</A> (Compare)
 subtracts the source operand from the destination operand. It
 updates OF, SF, ZF, AF, PF, and CF but does not alter the source and
-destination operands. A subsequent 
-<A HREF="Jcc.htm">Jcc</A> or 
+destination operands. A subsequent
+<A HREF="Jcc.htm">Jcc</A> or
 <A HREF="SETcc.htm">SETcc</A> instruction can test the appropriate flags.
 <P>
-<A HREF="NEG.htm">NEG</A> (Negate) 
+<A HREF="NEG.htm">NEG</A> (Negate)
 subtracts a signed integer operand from zero. The effect of
-<A HREF="NEG.htm">NEG</A> is to reverse the sign of the operand 
+<A HREF="NEG.htm">NEG</A> is to reverse the sign of the operand
 from positive to negative or from negative to positive.
 
 <H2>3.2.3  Multiplication Instructions</H2>
 The 80386 has separate multiply instructions for unsigned and signed
-operands. 
-<A HREF="MUL.htm">MUL</A> operates on unsigned numbers, while 
+operands.
+<A HREF="MUL.htm">MUL</A> operates on unsigned numbers, while
 <A HREF="IMUL.htm">IMUL</A> operates on signed
 integers as well as unsigned.
 <P>
-<A HREF="MUL.htm">MUL</A> (Unsigned Integer Multiply) 
+<A HREF="MUL.htm">MUL</A> (Unsigned Integer Multiply)
 performs an unsigned multiplication of the
 source operand and the accumulator. If the source is a byte, the processor
 multiplies it by the contents of AL and returns the double-length result to
 AH and AL. If the source operand is a word, the processor multiplies it by
 the contents of AX and returns the double-length result to DX and AX. If the
 source operand is a doubleword, the processor multiplies it by the contents
-of EAX and returns the 64-bit result in EDX and EAX. 
+of EAX and returns the 64-bit result in EDX and EAX.
 <A HREF="MUL.htm">MUL</A> sets CF and OF
 when the upper half of the result is nonzero; otherwise, they are cleared.
 <P>
-<A HREF="IMUL.htm">IMUL</A> (Signed Integer Multiply) 
+<A HREF="IMUL.htm">IMUL</A> (Signed Integer Multiply)
 performs a signed multiplication operation.
 <A HREF="IMUL.htm">IMUL</A> has three variations:
 <OL>
 <LI>A one-operand form. The operand may be a byte, word, or doubleword
 located in memory or in a general register. This instruction uses EAX
-and EDX as implicit operands in the same way as the 
+and EDX as implicit operands in the same way as the
 <A HREF="MUL.htm">MUL</A> instruction.
 <LI>A two-operand form. One of the source operands may be in any general
 register while the other may be either in memory or in a general
@@ -177,24 +177,24 @@ high-order half of the result is the sign-extension of the low-order half.
 However, forms 2 and 3 differ in that the product is truncated to the
 length of the operands before it is stored in the destination register.
 Because of this truncation, OF should be tested to ensure that no
-significant bits are lost. (For ways to test OF, refer to the 
+significant bits are lost. (For ways to test OF, refer to the
 <A HREF="INT.htm">INTO</A> and <A HREF="PUSHF.htm">PUSHF</A> instructions.)
 <P>
-Forms 2 and 3 of 
+Forms 2 and 3 of
 <A HREF="IMUL.htm">IMUL</A> may also be used with unsigned operands because,
 whether the operands are signed or unsigned, the low-order half of the
 product is the same.
 
 <H2>3.2.4  Division Instructions</H2>
 The 80386 has separate division instructions for unsigned and signed
-operands. 
-<A HREF="DIV.htm">DIV</A> operates on unsigned numbers, while 
+operands.
+<A HREF="DIV.htm">DIV</A> operates on unsigned numbers, while
 <A HREF="IDIV.htm">IDIV</A> operates on signed
 integers as well as unsigned. In either case, an exception (interrupt zero)
 occurs if the divisor is zero or if the quotient is too large for AL, AX, or
 EAX.
 <P>
-<A HREF="DIV.htm">DIV</A> (Unsigned Integer Divide) 
+<A HREF="DIV.htm">DIV</A> (Unsigned Integer Divide)
 performs an unsigned division of the
 accumulator by the source operand. The dividend (the accumulator) is twice
 the size of the divisor (the source operand); the quotient and remainder
@@ -211,10 +211,10 @@ always less than the divisor. For unsigned byte division, the largest
 quotient is 255. For unsigned word division, the largest quotient is 65,535.
 For unsigned doubleword division the largest quotient is 2^(32) -1.
 <P>
-<A HREF="IDIV.htm">IDIV</A> (Signed Integer Divide) 
+<A HREF="IDIV.htm">IDIV</A> (Signed Integer Divide)
 performs a signed division of the accumulator
-by the source operand. 
-<A HREF="IDIV.htm">IDIV</A> uses the same registers as the 
+by the source operand.
+<A HREF="IDIV.htm">IDIV</A> uses the same registers as the
 <A HREF="DIV.htm">DIV</A> instruction.
 <P>
 For signed byte division, the maximum positive quotient is +127, and the

--- a/s03_05.htm
+++ b/s03_05.htm
@@ -18,10 +18,10 @@ depend on the results of operations that affect the flag register.
 Unconditional control transfers are always executed.
 
 <H2>3.5.1  Unconditional Transfer Instructions</H2>
-<A HREF="JMP.htm">JMP</A>, 
-<A HREF="CALL.htm">CALL</A>, 
-<A HREF="RET.htm">RET</A>, 
-<A HREF="INT.htm">INT</A> and 
+<A HREF="JMP.htm">JMP</A>,
+<A HREF="CALL.htm">CALL</A>,
+<A HREF="RET.htm">RET</A>,
+<A HREF="INT.htm">INT</A> and
 <A HREF="IRET.htm">IRET</A> instructions transfer control from one code
 segment location to another. These locations can be within the same code
 segment (near control transfers) or in different code segments (far control
@@ -32,26 +32,26 @@ not make segments visible to applications programmers, intersegment control
 transfers will not be used.
 
 <H3>3.5.1.1  Jump Instruction</H3>
-<A HREF="JMP.htm">JMP</A> (Jump) 
-unconditionally transfers control to the target location. 
+<A HREF="JMP.htm">JMP</A> (Jump)
+unconditionally transfers control to the target location.
 <A HREF="JMP.htm">JMP</A> is
 a one-way transfer of execution; it does not save a return address on the
 stack.
 <P>
-The <A HREF="JMP.htm">JMP</A> 
+The <A HREF="JMP.htm">JMP</A>
 instruction always performs the same basic function of transferring
 control from the current location to a new location. Its implementation
 varies depending on whether the address is specified directly within the
 instruction or indirectly through a register or memory.
 <P>
-A direct <A HREF="JMP.htm">JMP</A> 
+A direct <A HREF="JMP.htm">JMP</A>
 instruction includes the destination address as part of the
-instruction. An indirect 
+instruction. An indirect
 <A HREF="JMP.htm">JMP</A> instruction obtains the destination address
 indirectly through a register or a pointer variable.
 <P>
-Direct near 
-<A HREF="JMP.htm">JMP</A>. A direct 
+Direct near
+<A HREF="JMP.htm">JMP</A>. A direct
 <A HREF="JMP.htm">JMP</A> uses a relative displacement value contained
 in the instruction. The displacement is signed and the size of the
 displacement may be a byte, word, or doubleword. The processor forms an
@@ -59,12 +59,12 @@ effective address by adding this relative displacement to the address
 contained in EIP. When the additions have been performed, EIP refers to the
 next instruction to be executed.
 <P>
-Indirect near 
-<A HREF="JMP.htm">JMP</A>. Indirect 
+Indirect near
+<A HREF="JMP.htm">JMP</A>. Indirect
 <A HREF="JMP.htm">JMP</A> instructions specify an absolute address in
 one of several ways:
 <OL>
-<LI> The program can 
+<LI> The program can
 <A HREF="JMP.htm">JMP</A> to a location specified by a general register
 (any of EAX, EDX, ECX, EBX, EBP, ESI, or EDI). The processor moves
 this 32-bit value into EIP and resumes execution.
@@ -77,23 +77,23 @@ destination address.
 </OL>
 
 <H3>3.5.1.2  Call Instruction</H3>
-<A HREF="CALL.htm">CALL</A> (Call Procedure) 
+<A HREF="CALL.htm">CALL</A> (Call Procedure)
 activates an out-of-line procedure, saving on the
-stack the address of the instruction following the 
+stack the address of the instruction following the
 <A HREF="CALL.htm">CALL</A> for later use by a
-<A HREF="RET.htm">RET</A> (Return) instruction. 
+<A HREF="RET.htm">RET</A> (Return) instruction.
 <A HREF="CALL.htm">CALL</A> places the current value of EIP on the stack.
 The <A HREF="RET.htm">RET</A> instruction in the called procedure uses this address to transfer
 control back to the calling program.
 <P>
-<A HREF="CALL.htm">CALL</A> instructions, like 
+<A HREF="CALL.htm">CALL</A> instructions, like
 <A HREF="JMP.htm">JMP</A> instructions have relative, direct, and
 indirect versions.
 <P>
-Indirect <A HREF="CALL.htm">CALL</A> 
+Indirect <A HREF="CALL.htm">CALL</A>
 instructions specify an absolute address in one of these ways:
 <OL>
-<LI> The program can 
+<LI> The program can
 <A HREF="CALL.htm">CALL</A> a location specified by a general register (any
 of EAX, EDX, ECX, EBX, EBP, ESI, or EDI). The processor moves this
 32-bit value into EIP.
@@ -102,23 +102,23 @@ operand specified in the instruction.
 </OL>
 
 <H3>3.5.1.3  Return and Return-From-Interrupt Instruction</H3>
-<A HREF="RET.htm">RET</A> (Return From Procedure) 
+<A HREF="RET.htm">RET</A> (Return From Procedure)
 terminates the execution of a procedure and
 transfers control through a back-link on the stack to the program that
-originally invoked the procedure. 
+originally invoked the procedure.
 <A HREF="RET.htm">RET</A> restores the value of EIP that was
 saved on the stack by the previous <A HREF="CALL.htm">CALL</A> instruction.
 <P>
-<A HREF="RET.htm">RET</A> instructions may optionally 
+<A HREF="RET.htm">RET</A> instructions may optionally
 specify an immediate operand. By adding
-this constant to the new top-of-stack pointer, 
+this constant to the new top-of-stack pointer,
 <A HREF="RET.htm">RET</A> effectively removes any
 arguments that the calling program pushed on the stack before the execution
 of the <A HREF="CALL.htm">CALL</A> instruction.
 <P>
-<A HREF="IRET.htm">IRET</A> (Return From Interrupt) 
+<A HREF="IRET.htm">IRET</A> (Return From Interrupt)
 returns control to an interrupted procedure.
-<A HREF="IRET.htm">IRET</A> differs from 
+<A HREF="IRET.htm">IRET</A> differs from
 <A HREF="RET.htm">RET</A> in that it also pops the flags from the stack into the
 flags register. The flags are stored on the stack by the interrupt
 mechanism.
@@ -176,112 +176,112 @@ instructions automatically decrement ECX and terminate the loop when ECX=0.
 Four of the five loop instructions specify a condition involving ZF that
 terminates the loop before ECX reaches zero.
 <P>
-<A HREF="LOOP.htm">LOOP</A> (Loop While ECX Not Zero) 
+<A HREF="LOOP.htm">LOOP</A> (Loop While ECX Not Zero)
 is a conditional transfer that automatically
 decrements the ECX register before testing ECX for the branch condition. If
 ECX is non-zero, the program branches to the target label specified in the
-instruction. The 
+instruction. The
 <A HREF="LOOP.htm">LOOP</A> instruction causes the repetition of a code section
-until the operation of the 
+until the operation of the
 <A HREF="LOOP.htm">LOOP</A> instruction decrements ECX to a value of
-zero. If 
-<A HREF="LOOP.htm">LOOP</A> finds ECX=0, 
+zero. If
+<A HREF="LOOP.htm">LOOP</A> finds ECX=0,
 control transfers to the instruction immediately
-following the 
-<A HREF="LOOP.htm">LOOP</A> instruction. 
+following the
+<A HREF="LOOP.htm">LOOP</A> instruction.
 If the value of ECX is initially zero, then
 the <A HREF="LOOP.htm">LOOP</A> executes 2^(32) times.
 <P>
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPE</A> (Loop While Equal) and 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPZ</A> (Loop While Zero) are synonyms for the
+<A HREF="LOOP.htm">LOOPE</A> (Loop While Equal) and
+<A HREF="LOOP.htm">LOOPZ</A> (Loop While Zero) are synonyms for the
 same instruction. These instructions automatically decrement the ECX
 register before testing ECX and ZF for the branch conditions. If ECX is
 non-zero and ZF=1, the program branches to the target label specified in the
-instruction. If 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPE</A> or 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPZ</A> finds that ECX=0 or ZF=0, control transfers
-to the instruction immediately following the 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPE</A> or
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPZ</A> instruction.
+instruction. If
+<A HREF="LOOP.htm">LOOPE</A> or
+<A HREF="LOOP.htm">LOOPZ</A> finds that ECX=0 or ZF=0, control transfers
+to the instruction immediately following the
+<A HREF="LOOP.htm">LOOPE</A> or
+<A HREF="LOOP.htm">LOOPZ</A> instruction.
 <P>
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNE</A> (Loop While Not Equal) and 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNZ</A> (Loop While Not Zero) are synonyms
+<A HREF="LOOP.htm">LOOPNE</A> (Loop While Not Equal) and
+<A HREF="LOOP.htm">LOOPNZ</A> (Loop While Not Zero) are synonyms
 for the same instruction. These instructions automatically decrement the ECX
 register before testing ECX and ZF for the branch conditions. If ECX is
 non-zero and ZF=0, the program branches to the target label specified in the
-instruction. If 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNE</A> or 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNZ</A> finds that ECX=0 or ZF=1, control transfers
-to the instruction immediately following the 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNE</A> or 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/LOOPcond.htm">LOOPNZ</A> instruction.
+instruction. If
+<A HREF="LOOP.htm">LOOPNE</A> or
+<A HREF="LOOP.htm">LOOPNZ</A> finds that ECX=0 or ZF=1, control transfers
+to the instruction immediately following the
+<A HREF="LOOP.htm">LOOPNE</A> or
+<A HREF="LOOP.htm">LOOPNZ</A> instruction.
 
 <H3>3.5.2.3  Executing a Loop or Repeat Zero Times</H3>
-<A HREF="Jcc.htm">JCXZ</A> (Jump if ECX Zero) 
+<A HREF="Jcc.htm">JCXZ</A> (Jump if ECX Zero)
 branches to the label specified in the instruction
-if it finds a value of zero in ECX. 
+if it finds a value of zero in ECX.
 <A HREF="Jcc.htm">JCXZ</A> is useful in combination with the
-<A HREF="LOOP.htm">LOOP</A> instruction and with the string 
+<A HREF="LOOP.htm">LOOP</A> instruction and with the string
 scan and compare instructions, all of
 which decrement ECX. Sometimes, it is desirable to design a loop that
 executes zero times if the count variable in ECX is initialized to zero.
-Because the 
-<A HREF="LOOP.htm">LOOP</A> instructions (and repeat prefixes) 
+Because the
+<A HREF="LOOP.htm">LOOP</A> instructions (and repeat prefixes)
 decrement ECX before
 they test it, a loop will execute 2^(32) times if the program enters the
 loop with a zero value in ECX. A programmer may conveniently overcome this
-problem with 
+problem with
 <A HREF="Jcc.htm">JCXZ</A>, which enables the program to branch around the code
-within the loop if ECX is zero when 
+within the loop if ECX is zero when
 <A HREF="Jcc.htm">JCXZ</A> executes. When used with repeated
-string scan and compare instructions, 
+string scan and compare instructions,
 <A HREF="Jcc.htm">JCXZ</A> can determine whether the
 repetitions terminated due to zero in ECX or due to satisfaction of the
 scan or compare conditions.
 
 <H2>3.5.3  Software-Generated Interrupts</H2>
-The 
-<A HREF="INT.htm">INT n</A>, 
-<A HREF="INT.htm"INTO</A>, and 
+The
+<A HREF="INT.htm">INT n</A>,
+<A HREF="INT.htm"INTO</A>, and
 <A HREF="BOUND.htm">BOUND</A> instructions allow the programmer to specify a
 transfer to an interrupt service routine from within a program.
 <P>
-<A HREF="INT.htm">INT n</A> (Software Interrupt) 
+<A HREF="INT.htm">INT n</A> (Software Interrupt)
 activates the interrupt service routine that
-corresponds to the number coded within the instruction. The 
+corresponds to the number coded within the instruction. The
 <A HREF="INT.htm">INT</A> instruction
 may specify any interrupt type. Programmers may use this flexibility to
 implement multiple types of internal interrupts or to test the operation of
 interrupt service routines. (Interrupts 0-31 are reserved by Intel.) The
-interrupt service routine terminates with an 
+interrupt service routine terminates with an
 <A HREF="IRET.htm">IRET</A> instruction that returns
 control to the instruction that follows <A HREF="INT.htm">INT n</A>.
 <P>
-<A HREF="INT.htm">INTO</A> (Interrupt on Overflow) 
+<A HREF="INT.htm">INTO</A> (Interrupt on Overflow)
 invokes interrupt 4 if OF is set. Interrupt 4
 is reserved for this purpose. OF is set by several arithmetic, logical, and
 string instructions.
 <P>
-<A HREF="BOUND.htm">BOUND</A> (Detect Value Out of Range) 
+<A HREF="BOUND.htm">BOUND</A> (Detect Value Out of Range)
 verifies that the signed value contained
-in the specified register lies within specified limits. An interrupt 
+in the specified register lies within specified limits. An interrupt
 (<A HREF="INT.htm">INT</A> 5)
 occurs if the value contained in the register is less than the lower bound
 or greater than the upper bound.
 <P>
-The <A HREF="BOUND.htm">BOUND</A> instruction includes two operands. 
+The <A HREF="BOUND.htm">BOUND</A> instruction includes two operands.
 The first operand specifies
 the register being tested. The second operand contains the effective
-relative address of the two signed 
-<A HREF="BOUND.htm">BOUND</A> limit values. The 
+relative address of the two signed
+<A HREF="BOUND.htm">BOUND</A> limit values. The
 <A HREF="BOUND.htm">BOUND</A> instruction
 assumes that the upper limit and lower limit are in adjacent memory
 locations. These limit values cannot be register operands; if they are, an
 invalid opcode exception occurs.
 <P>
-<A HREF="BOUND.htm">BOUND</A> is useful for checking array 
+<A HREF="BOUND.htm">BOUND</A> is useful for checking array
 bounds before using a new index value to
-access an element within the array. 
+access an element within the array.
 <A HREF="BOUND.htm">BOUND</A> provides a simple way to check the
 value of an index register before the program overwrites information in a
 location beyond the limit of the array.

--- a/s13_03.htm
+++ b/s13_03.htm
@@ -42,32 +42,32 @@ The 80286 processor implements the bus lock function differently than the
 not execute properly when transported to a specific application of the
 80386.
 <P>
-The <A HREF="LOCK.htm">LOCK</A> 
+The <A HREF="LOCK.htm">LOCK</A>
 prefix and its corresponding output signal should only be used to
-prevent other bus masters from interrupting a data movement operation.  
+prevent other bus masters from interrupting a data movement operation.
 <A HREF="LOCK.htm">LOCK</A>
 may only be used with the following 80386 instructions when they modify
-memory. An undefined-opcode exception results from using 
+memory. An undefined-opcode exception results from using
 <A HREF="LOCK.htm">LOCK</A> before any
 other instruction.
 <UL>
-<LI> Bit test and change: <A HREF="BTS.htm">BTS</A>, 
-<A HREF="BTR.htm">BTR</A>, 
+<LI> Bit test and change: <A HREF="BTS.htm">BTS</A>,
+<A HREF="BTR.htm">BTR</A>,
 <A HREF="BTC.htm">BTC</A>.
-<LI> Exchange: 
-<A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/XCGH.htm">XCHG</A>.
-<LI> One-operand arithmetic and logical: 
-<A HREF="INC.htm">INC</A>, 
-<A HREF="DEC.htm">DEC</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<LI> Exchange:
+<A HREF="XCHG.htm">XCHG</A>.
+<LI> One-operand arithmetic and logical:
+<A HREF="INC.htm">INC</A>,
+<A HREF="DEC.htm">DEC</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>.
-<LI> Two-operand arithmetic and logical: 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
+<LI> Two-operand arithmetic and logical:
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
 <A HREF="SBB.htm">SBB</A>,
- <A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
+ <A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
 <A HREF="XOR.htm">XOR</A>.
 </UL>
 A locked instruction is guaranteed to lock only the area of memory defined
@@ -85,9 +85,9 @@ for the 80286.
 <DT>
 Exception #6 -- invalid opcode
 <DD>
-This exception can result from improper use of the 
+This exception can result from improper use of the
 <A HREF="LOCK.htm">LOCK</A> instruction.
-<DT> 
+<DT>
 Exception #14 -- page fault
 <DD>
 This exception may occur in an 80286 program if the operating system
@@ -103,5 +103,5 @@ change the value of PDBR. Tasks ported from the 80286 should be given
 <B>up:</B> <A HREF="c13.htm">
 Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR>
 <B>prev:</B> <A HREF="s13_02.htm">13.2  Two ways to Execute 80286 Tasks</A><BR>
-<B>next:</B> <A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode</A> 
+<B>next:</B> <A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode</A>
 </BODY>


### PR DESCRIPTION
Hi,

I use JOS and this manual in my courses, was looking at broken links in this reference, and found this project. 

Here are some fixes that I made locally.  This project links back to the MIT page for every broken link, but they aren't there at MIT either.  I am pretty confident these are the right links, and some are just about case sensitivity, but happy to discuss.

Thanks!