### PR TITLE
Add explicit language to html tags, for accessibility

### DIFF
--- a/AAA.htm
+++ b/AAA.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AAA</TITLE>
 </HEAD>
@@ -37,9 +37,9 @@ FI;
 
 <H2>Description</H2>
 
-Execute AAA only following an 
+Execute AAA only following an
 <A HREF="ADD.htm">ADD</A> instruction that leaves a byte result
-in the AL register. The lower nibbles of the operands of the 
+in the AL register. The lower nibbles of the operands of the
 <A HREF="ADD.htm">ADD</A> instruction
 should be in the range 0 through 9 (BCD digits). In this case, AAA adjusts
 AL to contain the correct decimal digit result. If the addition produced a

--- a/AAD.htm
+++ b/AAD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AAD</TITLE>
 </HEAD>

--- a/AAM.htm
+++ b/AAM.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AAM</TITLE>
 </HEAD>
@@ -28,7 +28,7 @@ AL := AL MOD 10;
 
 <H2>Description</H2>
 
-Execute AAM only after executing a 
+Execute AAM only after executing a
 <A HREF="MUL.htm">MUL</A> instruction between two unpacked
 BCD digits that leaves the result in the AX register. Because the result is
 less than 100, it is contained entirely in the AL register. AAM unpacks the

--- a/AAS.htm
+++ b/AAS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AAS</TITLE>
 </HEAD>
@@ -37,9 +37,9 @@ FI;
 
 <H2>Description</H2>
 
-Execute AAS only after a 
+Execute AAS only after a
 <A HREF="SUB.htm">SUB</A> instruction that leaves the byte result in the
-AL register. The lower nibbles of the operands of the 
+AL register. The lower nibbles of the operands of the
 <A HREF="SUB.htm">SUB</A> instruction must
 have been in the range 0 through 9 (BCD digits). In this case, AAS adjusts
 AL so it contains the correct decimal digit result. If the subtraction

--- a/ADC.htm
+++ b/ADC.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode ADC</TITLE>
 </HEAD>

--- a/ADD.htm
+++ b/ADD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode ADD</TITLE>
 </HEAD>

--- a/AND.htm
+++ b/AND.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AND</TITLE>
 </HEAD>

--- a/ARPL.htm
+++ b/ARPL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode ARPL</TITLE>
 </HEAD>

--- a/BOUND.htm
+++ b/BOUND.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BOUND</TITLE>
 </HEAD>

--- a/BSF.htm
+++ b/BSF.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BSF</TITLE>
 </HEAD>

--- a/BSR.htm
+++ b/BSR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BSR</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="BSF.htm"> BSF Bit Scan Forward</A><BR>
-<B>next:</B><A HREF="BT.htm"> BT Bit Test</A> 
+<B>next:</B><A HREF="BT.htm"> BT Bit Test</A>
 <P>
 <HR>
 <P>
@@ -73,5 +73,5 @@ Same exceptions as in Real Address Mode; #PF(fault-code) for a page fault
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="BSF.htm"> BSF Bit Scan Forward</A><BR>
-<B>next:</B><A HREF="BT.htm"> BT Bit Test</A> 
+<B>next:</B><A HREF="BT.htm"> BT Bit Test</A>
 </BODY>

--- a/BT.htm
+++ b/BT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BT</TITLE>
 </HEAD>
@@ -79,7 +79,7 @@ given by:
 for a 16-bit operand size. It may do so even when only a single byte needs
 to be accessed in order to reach the given bit. You must therefore avoid
 referencing areas of memory close to address space holes. In particular,
-avoid references to memory-mapped I/O registers. Instead, use the 
+avoid references to memory-mapped I/O registers. Instead, use the
 <A HREF="MOV.htm">MOV</A>
 instructions to load from or store to these addresses, and use the register
 form of these instructions to manipulate the data.

--- a/BTC.htm
+++ b/BTC.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BTC</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="BT.htm"> BT Bit Test</A><BR> 
+<B>prev:</B><A HREF="BT.htm"> BT Bit Test</A><BR>
 <B>next:</B><A HREF="BTR.htm"> BTR Bit Test and Reset</A>
 <P>
 <HR>

--- a/BTR.htm
+++ b/BTR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BTR</TITLE>
 </HEAD>
@@ -80,7 +80,7 @@ given by:
 for a 16-bit operand size. It may do so even when only a single byte needs
 to be accessed in order to reach the given bit. You must therefore avoid
 referencing areas of memory close to address space holes. In particular,
-avoid references to memory-mapped I/O registers. Instead, use the 
+avoid references to memory-mapped I/O registers. Instead, use the
 <A HREF="MOV.htm">MOV</A>
 instructions to load from or store to these addresses, and use the register
 form of these instructions to manipulate the data.

--- a/BTS.htm
+++ b/BTS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode BTS</TITLE>
 </HEAD>

--- a/CALL.htm
+++ b/CALL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CALL</TITLE>
 </HEAD>
@@ -279,7 +279,7 @@ the CALL instruction.
 <P>
 The action of the different forms of the instruction are described below.
 <P>
-<STRONG>Near calls</STRONG> 
+<STRONG>Near calls</STRONG>
 are those with destinations of type r/m16, r/m32, rel16, rel32;
 changing or saving the segment register value is not necessary. The CALL
 rel16 and CALL rel32 forms add a signed offset to the address of the
@@ -292,11 +292,11 @@ CALL r/m32 specify a register or memory location from which the absolute
 segment offset is fetched. The offset fetched from r/m is 32 bits for an
 operand-size attribute of 32 (r/m32), or 16 bits for an operand-size of 16
 (r/m16). The offset of the instruction following CALL is pushed onto the
-stack. It will be popped by a near 
+stack. It will be popped by a near
 <A HREF="RET.htm">RET</A> instruction within the procedure. The
 CS register is not changed by this form of CALL.
 <P>
-The <STRONG>far calls</STRONG>, 
+The <STRONG>far calls</STRONG>,
 CALL ptr16:16 and CALL ptr16:32, use a four-byte or six-byte
 operand as a long pointer to the procedure called. The CALL m16:16 and
 m16:32 forms fetch the long pointer from the memory location
@@ -325,15 +325,15 @@ task switch does not occur
 
 <H2>Protected Mode Exceptions</H2>
 
-For <STRONG>far calls</STRONG>: 
+For <STRONG>far calls</STRONG>:
 #GP, #NP, #SS, and #TS, as indicated in the list above
 <P>
-For <STRONG>near direct calls</STRONG>: 
+For <STRONG>near direct calls</STRONG>:
 #GP(0) if procedure location is beyond the code
 segment limits; #SS(0) if pushing the return address exceeds the bounds of
 the stack segment; #PF (fault-code) for a page fault
 
-For a <STRONG>near indirect call</STRONG>: 
+For a <STRONG>near indirect call</STRONG>:
 #GP(0) for an illegal memory operand effective
 address in the CS, DS, ES, FS, or GS segments; #SS(0) for an illegal address
 in the SS segment; #GP(0) if the indirect offset obtained is beyond the code

--- a/CBW.htm
+++ b/CBW.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CBW</TITLE>
 </HEAD>

--- a/CLC.htm
+++ b/CLC.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CLC</TITLE>
 </HEAD>

--- a/CLD.htm
+++ b/CLD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CLD</TITLE>
 </HEAD>

--- a/CLI.htm
+++ b/CLI.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CLI</TITLE>
 </HEAD>

--- a/CLTS.htm
+++ b/CLTS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CLTS</TITLE>
 </HEAD>

--- a/CMC.htm
+++ b/CMC.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CMC</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="CLTS.htm"> CLTS Clear Task-Switched Flag in CR0</A><BR>
-<B>next:</B><A HREF="CMP.htm"> CMP Compare Two Operands</A> 
+<B>next:</B><A HREF="CMP.htm"> CMP Compare Two Operands</A>
 <P>
 <HR>
 <P>
@@ -53,5 +53,5 @@ None
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="CLTS.htm"> CLTS Clear Task-Switched Flag in CR0</A><BR>
-<B>next:</B><A HREF="CMP.htm"> CMP Compare Two Operands</A> 
+<B>next:</B><A HREF="CMP.htm"> CMP Compare Two Operands</A>
 </BODY>

--- a/CMP.htm
+++ b/CMP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CMP</TITLE>
 </HEAD>
@@ -53,10 +53,10 @@ LeftSRC - SignExtend(RightSRC);
 
 <H2>Description</H2>
 
-CMP subtracts the second operand from the first but, unlike the 
+CMP subtracts the second operand from the first but, unlike the
 <A HREF="SUB.htm">SUB</A>
 instruction, does not store the result; only the flags are changed. CMP is
-typically used in conjunction with conditional jumps and the 
+typically used in conjunction with conditional jumps and the
 <A HREF="SETcc.htm">SETcc</A>
 instruction. (Refer to Appendix D for the list of signed and unsigned flag
 tests provided.) If an operand greater than one byte is compared to an

--- a/CMPS.htm
+++ b/CMPS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CMPS</TITLE>
 </HEAD>
@@ -18,13 +18,13 @@ Chapter 17 -- 80386 Instruction Set</A><BR>
 Opcode    Instruction        Clocks   Description
 
 A6        CMPS m8,m8         10       Compare bytes ES:[(E)DI] (second
-                                      operand) with   [(E)SI] (first 
+                                      operand) with   [(E)SI] (first
                                       operand)
 A7        CMPS m16,m16       10       Compare words ES:[(E)DI] (second
-                                      operand) with   [(E)SI] (first 
+                                      operand) with   [(E)SI] (first
                                       operand)
 A7        CMPS m32,m32       10       Compare dwords ES:[(E)DI]
-                                      (second operand) with [(E)SI] 
+                                      (second operand) with [(E)SI]
                                       (first operand)
 A6        CMPSB              10       Compare bytes ES:[(E)DI] with
                                       DS:[SI]
@@ -97,7 +97,7 @@ possible.
 After the comparison is made, both the source-index register and
 destination-index register are automatically advanced. If the direction flag
 is 0 (<A HREF="CLD.htm">CLD</A> was executed), the registers increment; if the direction flag is 1
-(<A HREF="STD.htm">STD</A> was executed), 
+(<A HREF="STD.htm">STD</A> was executed),
 the registers decrement. The registers increment or
 decrement by 1 if a byte is compared, by 2 if a word is compared, or by 4 if
 a doubleword is compared.
@@ -105,10 +105,10 @@ a doubleword is compared.
 CMPSB, CMPSW and CMPSD are synonyms for the byte, word, and
 doubleword CMPS instructions, respectively.
 <P>
-CMPS can be preceded by the 
-<A HREF="REP.htm">REPE</A> or <A HREF="REP.htm">REPNE</A> 
+CMPS can be preceded by the
+<A HREF="REP.htm">REPE</A> or <A HREF="REP.htm">REPNE</A>
 prefix for block comparison of CX
-or ECX bytes, words, or doublewords. Refer to the description of the 
+or ECX bytes, words, or doublewords. Refer to the description of the
 <A HREF="REP.htm">REP</A>
 instruction for more information on this operation.
 

--- a/CWD.htm
+++ b/CWD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode CWD</TITLE>
 </HEAD>

--- a/DAA.htm
+++ b/DAA.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode DAA</TITLE>
 </HEAD>
@@ -39,9 +39,9 @@ FI;
 
 <H2>Description</H2>
 
-Execute DAA only after executing an 
+Execute DAA only after executing an
 <A HREF="ADD.htm">ADD</A> instruction that leaves a
-two-BCD-digit byte result in the AL register. The 
+two-BCD-digit byte result in the AL register. The
 <A HREF="ADD.htm">ADD</A> operands should
 consist of two packed BCD digits. The DAA instruction adjusts AL to
 contain the correct two-digit packed decimal result.

--- a/DAS.htm
+++ b/DAS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode DAS</TITLE>
 </HEAD>

--- a/DEC.htm
+++ b/DEC.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode DEC</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="DAS.htm"> DAS Decimal Adjust AL after Subtraction</A><BR>
-<B>next:</B><A HREF="DIV.htm"> DIV Unsigned Divide</A> 
+<B>next:</B><A HREF="DIV.htm"> DIV Unsigned Divide</A>
 <P>
 <HR>
 <P>
@@ -32,7 +32,7 @@ DEST := DEST - 1;
 <H2>Description</H2>
 
 DEC subtracts 1 from the operand. DEC does not change the carry flag.
-To affect the carry flag, use the 
+To affect the carry flag, use the
 <A HREF="SUB.htm">SUB</A> instruction with an immediate
 operand of 1.
 
@@ -64,5 +64,5 @@ fault
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="DAS.htm"> DAS Decimal Adjust AL after Subtraction</A><BR>
-<B>next:</B><A HREF="DIV.htm"> DIV Unsigned Divide</A> 
+<B>next:</B><A HREF="DIV.htm"> DIV Unsigned Divide</A>
 </BODY>

--- a/DIV.htm
+++ b/DIV.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode DIV</TITLE>
 </HEAD>

--- a/ENTER.htm
+++ b/ENTER.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode ENTER</TITLE>
 </HEAD>
@@ -74,9 +74,9 @@ stack pointer and sets the frame pointer to the current stack-pointer
 value.
 <P>
 For example, a procedure with 12 bytes of local variables would have an
-ENTER 12,0 instruction at its entry point and a 
+ENTER 12,0 instruction at its entry point and a
 <A HREF="LEAVE.htm">LEAVE</A> instruction
-before every <A HREF="RET.htm">RET</A>. 
+before every <A HREF="RET.htm">RET</A>.
 The 12 local bytes would be addressed as negative
 offsets from the frame pointer.
 

--- a/HLT.htm
+++ b/HLT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode HLT</TITLE>
 </HEAD>

--- a/IDIV.htm
+++ b/IDIV.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode IDIV</TITLE>
 </HEAD>

--- a/IMUL.htm
+++ b/IMUL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode IMUL</TITLE>
 </HEAD>
@@ -43,7 +43,7 @@ F7  /5      IMUL r/m32             9-38/12-41  EDX:EAX := EAX * r/m dword
 69  /r id   IMUL r32,imm32         9-38/12-41  dword register := r/m32 *
                                                immediate dword
 </PRE>
-  
+
 <EM>
 <H3>Notes</H3>
   The 80386 uses an early-out multiply algorithm. The actual number of
@@ -54,8 +54,8 @@ F7  /5      IMUL r/m32             9-38/12-41  EDX:EAX := EAX * r/m dword
   the following formula:
 
 <PRE>
-  Actual clock = if m <> 0 then max(ceiling(log{2}(m)), 3) + 6 clocks  
-  Actual clock = if m = 0 then 9 clocks   
+  Actual clock = if m <> 0 then max(ceiling(log{2}(m)), 3) + 6 clocks
+  Actual clock = if m = 0 then 9 clocks
   (where m is the multiplier)
 </PRE>
 

--- a/IN.htm
+++ b/IN.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode IN</TITLE>
 </HEAD>

--- a/INC.htm
+++ b/INC.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode INC</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="IN.htm"> IN Input from Port</A><BR> 
+<B>prev:</B><A HREF="IN.htm"> IN Input from Port</A><BR>
 <B>next:</B><A HREF="INS.htm"> INS/INSB/INSW/INSD Input from Port to String</A>
 <P>
 <HR>
@@ -32,7 +32,7 @@ DEST := DEST + 1;
 <H2>Description</H2>
 
 INC adds 1 to the operand. It does not change the carry flag. To affect
-the carry flag, use the 
+the carry flag, use the
 <A HREF="ADD.htm">ADD</A> instruction with a second operand of 1.
 
 <H2>Flags Affected</H2>

--- a/INS.htm
+++ b/INS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode INS</TITLE>
 </HEAD>
@@ -87,9 +87,9 @@ increments or decrements by 1 if a byte is input, by 2 if a word is input,
 or by 4 if a doubleword is input.
 <P>
 INSB, INSW and INSD are synonyms of the byte, word, and doubleword
-INS instructions. INS can be preceded by the 
+INS instructions. INS can be preceded by the
 <A HREF="REP.htm">REP</A> prefix for block input of
-CX bytes or words. Refer to the 
+CX bytes or words. Refer to the
 <A HREF="REP.htm">REP</A> instruction for details of this
 operation.
 

--- a/INT.htm
+++ b/INT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode INT</TITLE>
 </HEAD>
@@ -252,8 +252,8 @@ these interrupts are use for internally generated exceptions.
 <P>
 INT n generally behaves like a far call except that the flags register is
 pushed onto the stack before the return address. Interrupt procedures
-return via the 
-<A HREF="IRET.htm">IRET</A> 
+return via the
+<A HREF="IRET.htm">IRET</A>
 instruction, which pops the flags and return address
 from the stack.
 <P>

--- a/IRET.htm
+++ b/IRET.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode IRET</TITLE>
 </HEAD>
@@ -263,7 +263,7 @@ the interrupt routine (as indicated by the RPL bits of the CS selector
 popped from the stack). If the destination code is less privileged, IRET
 also pops the stack pointer and SS from the stack.
 <P>
-If NT equals 1, IRET reverses the operation of a 
+If NT equals 1, IRET reverses the operation of a
 <A HREF="CALL.htm">CALL</A> or <A HREF="INT.htm">INT</A> that
 caused a task switch. The updated state of the task executing IRET is
 saved in its task state segment. If the task is reentered later, the code

--- a/JMP.htm
+++ b/JMP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode JMP</TITLE>
 </HEAD>

--- a/Jcc.htm
+++ b/Jcc.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode Jcc</TITLE>
 </HEAD>
@@ -166,8 +166,8 @@ synonym for JE.
 JCXZ differs from other conditional jumps because it tests the contents of
 the CX or ECX register for 0, not the flags. JCXZ is useful at the beginning
 of a conditional loop that terminates with a conditional loop instruction
-(such as 
-<A HREF="LOOP.htm">LOOPNE</A> 
+(such as
+<A HREF="LOOP.htm">LOOPNE</A>
 TARGET LABEL). The JCXZ prevents entering the loop with CX or
 ECX equal to zero, which would cause the loop to execute 64K or 32G times
 instead of zero times.

--- a/LAHF.htm
+++ b/LAHF.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LAHF</TITLE>
 </HEAD>

--- a/LAR.htm
+++ b/LAR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LAR</TITLE>
 </HEAD>

--- a/LEA.htm
+++ b/LEA.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LEA</TITLE>
 </HEAD>

--- a/LEAVE.htm
+++ b/LEAVE.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LEAVE</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="LEA.htm"> LEA Load Effective Address</A><BR> 
+<B>prev:</B><A HREF="LEA.htm"> LEA Load Effective Address</A><BR>
 <B>next:</B><A HREF="LGDT.htm"> LGDT/LIDT Load Global/Interrupt Descriptor Table Register</A>
 <P>
 <HR>
@@ -39,11 +39,11 @@ FI;
 
 <H2>Description</H2>
 
-LEAVE reverses the actions of the 
+LEAVE reverses the actions of the
 <A HREF="ENTER.htm">ENTER</A> instruction. By copying the
 frame pointer to the stack pointer, LEAVE releases the stack space used
 by a procedure for its local variables. The old frame pointer is popped
-into BP or EBP, restoring the caller's frame. A subsequent 
+into BP or EBP, restoring the caller's frame. A subsequent
 <A HREF="RET.htm">RET</A>
 instruction removes any arguments pushed onto the stack of the exiting
 procedure.
@@ -72,6 +72,6 @@ Same exceptions as in Real Address Mode
 <P>
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="LEA.htm"> LEA Load Effective Address</A><BR> 
+<B>prev:</B><A HREF="LEA.htm"> LEA Load Effective Address</A><BR>
 <B>next:</B><A HREF="LGDT.htm"> LGDT/LIDT Load Global/Interrupt Descriptor Table Register</A>
 </BODY>

--- a/LGDT.htm
+++ b/LGDT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LGDT</TITLE>
 </HEAD>
@@ -47,12 +47,12 @@ high-order eight bits of the six-byte data operand are not used. If a 32-bit
 operand is used, a 16-bit limit and a 32-bit base is loaded; the high-order
 eight bits of the six-byte operand are used as high-order base address bits.
 <P>
-The 
-<A HREF="SGDT.htm">SGDT</A> and 
+The
+<A HREF="SGDT.htm">SGDT</A> and
 <A HREF="SGDT.htm">SIDT</A> instructions always store into all 48 bits of the
 six-byte data operand. With the 80286, the upper eight bits are undefined
-after 
-<A HREF="SGDT.htm">SGDT</A> or 
+after
+<A HREF="SGDT.htm">SGDT</A> or
 <A HREF="SGDT.htm">SIDT</A> is executed. With the 80386, the upper eight bits
 are written with the high-order eight address bits, for both a 16-bit
 operand and a 32-bit operand. If LGDT or LIDT is used with a 16-bit

--- a/LGS.htm
+++ b/LGS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LGS</TITLE>
 </HEAD>

--- a/LLDT.htm
+++ b/LLDT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LLDT</TITLE>
 </HEAD>

--- a/LMSW.htm
+++ b/LMSW.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LMSW</TITLE>
 </HEAD>

--- a/LOCK.htm
+++ b/LOCK.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LOCK</TITLE>
 </HEAD>
@@ -26,7 +26,7 @@ during execution of the instruction that follows it. In a multiprocessor
 environment, this signal can be used to ensure that the 80386 has
 exclusive use of any shared memory while LOCK# is asserted. The
 read-modify-write sequence typically used to implement test-and-set on the
-80386 is the 
+80386 is the
 <A HREF="BTS.htm">BTS</A> instruction.
 <P>
 The LOCK prefix functions only with the following instructions:

--- a/LODS.htm
+++ b/LODS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LODS</TITLE>
 </HEAD>
@@ -66,10 +66,10 @@ determined solely by the contents of ESI/SI. Load the correct index value
 into SI before executing the LODS instruction. LODSB, LODSW, LODSD are
 synonyms for the byte, word, and doubleword LODS instructions.
 <P>
-LODS can be preceded by the 
+LODS can be preceded by the
 <A HREF="REP.htm">REP</A> prefix; however, LODS is used more typically
-within a 
-<A HREF="LOOP.htm">LOOP</A> construct, 
+within a
+<A HREF="LOOP.htm">LOOP</A> construct,
 because further processing of the data moved into
 EAX, AX, or AL is usually necessary.
 

--- a/LOOP.htm
+++ b/LOOP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LOOP</TITLE>
 </HEAD>

--- a/LSL.htm
+++ b/LSL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LSL</TITLE>
 </HEAD>

--- a/LTR.htm
+++ b/LTR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode LTR</TITLE>
 </HEAD>

--- a/MOV.htm
+++ b/MOV.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode MOV</TITLE>
 </HEAD>
@@ -136,5 +136,5 @@ fault
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="LTR.htm"> LTR Load Task Register</A><BR>
-<B>next:</B><A HREF="MOVRS.htm"> MOV Move to/from Special Registers</A> 
+<B>next:</B><A HREF="MOVRS.htm"> MOV Move to/from Special Registers</A>
 </BODY>

--- a/MOVRS.htm
+++ b/MOVRS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>
 80386 Programmer's Reference Manual -- Opcode MOV Special Registers
@@ -9,7 +9,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="MOV.htm"> MOV  Move Data</A><BR>
-<B>next:</B><A HREF="MOVS.htm"> 
+<B>next:</B><A HREF="MOVS.htm">
 MOVS/MOVSB/MOVSW/MOVSD  Move Data from String to String</A>
 <P>
 <HR>
@@ -86,6 +86,6 @@ always 11. The r/m field specifies the general register involved.
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="MOV.htm"> MOV  Move Data</A><BR>
-<B>next:</B><A HREF="MOVS.htm"> 
+<B>next:</B><A HREF="MOVS.htm">
 MOVS/MOVSB/MOVSW/MOVSD  Move Data from String to String</A>
 </BODY>

--- a/MOVS.htm
+++ b/MOVS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode MOVS</TITLE>
 </HEAD>
@@ -72,9 +72,9 @@ are incremented; if the direction flag is 1 (<A HREF="STD.htm">STD</A> was execu
 registers are decremented. The registers are incremented or decremented by 1
 if a byte was moved, 2 if a word was moved, or 4 if a doubleword was moved.
 <P>
-MOVS can be preceded by the 
+MOVS can be preceded by the
 <A HREF="REP.htm">REP</A> prefix for block movement of CX
-bytes or words. Refer to the 
+bytes or words. Refer to the
 <A HREF="REP.htm">REP</A> instruction for details of this operation.
 
 <H2>Flags Affected</H2>
@@ -102,6 +102,6 @@ fault
 <P>
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="MOVRS.htm"> MOV Move to/from Special Registers</A><BR> 
+<B>prev:</B><A HREF="MOVRS.htm"> MOV Move to/from Special Registers</A><BR>
 <B>next:</B><A HREF="MOVSX.htm"> MOVSX Move with Sign-Extend</A>
 </BODY>

--- a/MOVSX.htm
+++ b/MOVSX.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode MOVSX</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="MOVS.htm"> 
+<B>prev:</B><A HREF="MOVS.htm">
 MOVS/MOVSB/MOVSW/MOVSD Move Data from String to String</A><BR>
 <B>next:</B><A HREF="MOVZX.htm"> MOVZX Move with Zero-Extend</A>
 <P>
@@ -61,7 +61,7 @@ fault
 <P>
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
-<B>prev:</B><A HREF="MOVS.htm"> 
+<B>prev:</B><A HREF="MOVS.htm">
 MOVS/MOVSB/MOVSW/MOVSD Move Data from String to String</A><BR>
 <B>next:</B><A HREF="MOVZX.htm"> MOVZX Move with Zero-Extend</A>
 </BODY>

--- a/MOVZX.htm
+++ b/MOVZX.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode MOVZX</TITLE>
 </HEAD>

--- a/MUL.htm
+++ b/MUL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode MUL</TITLE>
 </HEAD>
@@ -26,7 +26,7 @@ F7  /4  MUL EAX,r/m32   9-38/12-41   Unsigned multiply (EDX:EAX := EAX * r/m
 <EM>
 <H3>Notes</H3>
   The 80386 uses an early-out multiply algorithm. The actual number of
-  clocks depends on the position of the most significant bit in the 
+  clocks depends on the position of the most significant bit in the
   optimizing multiplier, shown underlined above. The optimization occurs
   for positive and negative multiplier values. Because of the early-out
   algorithm, clock counts given are minimum to maximum. To calculate the

--- a/NEG.htm
+++ b/NEG.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode NEG</TITLE>
 </HEAD>

--- a/NOP.htm
+++ b/NOP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode NOP</TITLE>
 </HEAD>

--- a/NOT.htm
+++ b/NOT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode NOT</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="NOP.htm"> NOP No Operation</A><BR>
-<B>next:</B><A HREF="OR.htm"> OR Logical Inclusive OR</A> 
+<B>next:</B><A HREF="OR.htm"> OR Logical Inclusive OR</A>
 <P>
 <HR>
 <P>

--- a/OR.htm
+++ b/OR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode OR</TITLE>
 </HEAD>

--- a/OUT.htm
+++ b/OUT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode OUT</TITLE>
 </HEAD>

--- a/OUTS.htm
+++ b/OUTS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode OUTS</TITLE>
 </HEAD>
@@ -88,16 +88,16 @@ source-index register. Load the correct index value into SI or ESI before
 executing the OUTS instruction.
 <P>
 After the transfer, source-index register is advanced automatically. If
-the direction flag is 0 (<A HREF="CLD.htm">CLD</A> 
+the direction flag is 0 (<A HREF="CLD.htm">CLD</A>
 was executed), the source-index register is
 incremented; if the direction flag is 1 (<A HREF="STD.htm">STD</A> was executed), it is
 decremented. The amount of the increment or decrement is 1 if a byte is
 output, 2 if a word is output, or 4 if a doubleword is output.
 <P>
 OUTSB, OUTSW, and OUTSD are synonyms for the byte, word, and
-doubleword OUTS instructions. OUTS can be preceded by the 
+doubleword OUTS instructions. OUTS can be preceded by the
 <A HREF="REP.htm">REP</A>
-prefix for block output of CX bytes or words. Refer to the 
+prefix for block output of CX bytes or words. Refer to the
 <A HREF="REP.htm">REP</A>
 instruction for details on this operation.
 

--- a/PI.htm
+++ b/PI.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Part I</TITLE>
 </HEAD>
@@ -16,4 +16,3 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">Table of Contents</A>
 </BODY>
-

--- a/PII.htm
+++ b/PII.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Part II</TITLE>
 </HEAD>
@@ -23,4 +23,3 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">Table of Contents</A>
 </BODY>
-

--- a/PIII.htm
+++ b/PIII.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Part III</TITLE>
 </HEAD>
@@ -18,4 +18,3 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">Table of Contents</A>
 </BODY>
-

--- a/PIV.htm
+++ b/PIV.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Part IV</TITLE>
 </HEAD>
@@ -15,4 +15,3 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">Table of Contents</A>
 </BODY>
-

--- a/POP.htm
+++ b/POP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode POP</TITLE>
 </HEAD>
@@ -81,7 +81,7 @@ value of the segment register is null.
 A POP SS instruction inhibits all interrupts, including NMI, until after
 execution of the next instruction. This allows sequential execution of POP
 SS and POP eSP instructions without danger of having an invalid stack
-during an interrupt. However, use of the 
+during an interrupt. However, use of the
 <A HREF="LGS.htm">LSS</A> instruction is the preferred
 method of loading the SS and eSP registers.
 <P>

--- a/POPA.htm
+++ b/POPA.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode POPA</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="POP.htm"> POP Pop a Word from the Stack</A><BR>
-<B>next:</B><A HREF="POPF.htm"> 
+<B>next:</B><A HREF="POPF.htm">
 POPF/POPFD Pop Stack into FLAGS or EFLAGS Register</A>
 <P>
 <HR>
@@ -50,16 +50,16 @@ FI;
 <H2>Description</H2>
 
 POPA pops the eight 16-bit general registers. However, the SP value is
-discarded instead of loaded into SP. POPA reverses a previous 
+discarded instead of loaded into SP. POPA reverses a previous
 <A HREF="PUSHA.htm">PUSHA</A>,
-restoring the general registers to their values before 
+restoring the general registers to their values before
 <A HREF="PUSHA.htm">PUSHA</A> was
 executed. The first register popped is DI.
 <P>
 POPAD pops the eight 32-bit general registers. The ESP value is
 discarded instead of loaded into ESP. POPAD reverses the previous
-<A HREF="PUSHA.htm">PUSHAD</A>, 
-restoring the general registers to their values before 
+<A HREF="PUSHA.htm">PUSHAD</A>,
+restoring the general registers to their values before
 <A HREF="PUSHA.htm">PUSHAD</A>
 was executed. The first register popped is EDI.
 
@@ -89,6 +89,6 @@ fault
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="POP.htm"> POP Pop a Word from the Stack</A><BR>
-<B>next:</B><A HREF="POPF.htm"> 
+<B>next:</B><A HREF="POPF.htm">
 POPF/POPFD Pop Stack into FLAGS or EFLAGS Register</A>
 </BODY>

--- a/POPF.htm
+++ b/POPF.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode POPF</TITLE>
 </HEAD>
@@ -32,8 +32,8 @@ the instruction is 16 bits, then a word is popped and the value is stored in
 FLAGS. If the operand-size attribute is 32 bits, then a doubleword is popped
 and the value is stored in EFLAGS.
 <P>
-Refer to 
-<A HREF="c02.htm">Chapter 2</A> and 
+Refer to
+<A HREF="c02.htm">Chapter 2</A> and
 <A HREF="c04.htm">Chapter 4</A> for information about the FLAGS
 and EFLAGS registers. Note that bits 16 and 17 of EFLAGS, called
 VM and RF, respectively, are not affected by POPF or POPFD.

--- a/PUSH.htm
+++ b/PUSH.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode PUSH</TITLE>
 </HEAD>

--- a/PUSHA.htm
+++ b/PUSHA.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode PUSHA</TITLE>
 </HEAD>

--- a/PUSHF.htm
+++ b/PUSHF.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode PUSHF</TITLE>
 </HEAD>
@@ -35,9 +35,9 @@ FI;
 PUSHF decrements the stack pointer by 2 and copies the FLAGS
 register to the new top of stack; PUSHFD decrements the stack pointer by
 4, and the 80386 EFLAGS register is copied to the new top of stack
-which is pointed to by SS:eSP. Refer to 
-<A HREF="c02.htm">Chapter 2</A> and 
-<A HREF="c04.htm">Chapter 4</A> for 
+which is pointed to by SS:eSP. Refer to
+<A HREF="c02.htm">Chapter 2</A> and
+<A HREF="c04.htm">Chapter 4</A> for
 information on the EFLAGS register.
 
 <H2>Flags Affected</H2>

--- a/RCL.htm
+++ b/RCL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode RCL</TITLE>
 </HEAD>

--- a/REP.htm
+++ b/REP.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode REP</TITLE>
 </HEAD>
@@ -128,7 +128,7 @@ Synonymous forms of REPE and REPNE are REPZ and REPNZ,
 respectively.
 <P>
 The REP prefixes apply only to one string instruction at a time. To repeat
-a block of instructions, use the 
+a block of instructions, use the
 <A HREF="LOOP.htm">LOOP</A> instruction or another looping
 construct.
 <P>
@@ -148,7 +148,7 @@ The precise action for each iteration is as follows:
 
  <LI> Decrement CX or ECX by one; no flags are modified.
 
- <LI> Check the zero flag if the string operation is 
+ <LI> Check the zero flag if the string operation is
 <A HREF="SCAS.htm">SCAS</A> or <A HREF="CMPS.htm">CMPS</A>. If
       the repeat condition does not hold, exit the iteration and move to
       the next instruction. Exit the iteration if the prefix is REPE and ZF
@@ -158,19 +158,19 @@ The precise action for each iteration is as follows:
  <LI> Return to step 1 for the next iteration.
 </OL>
 
-Repeated 
-<A HREF="CMPS.htm">CMPS</A> and <A HREF="SCAS.htm">SCAS</A> 
+Repeated
+<A HREF="CMPS.htm">CMPS</A> and <A HREF="SCAS.htm">SCAS</A>
 instructions can be exited if the count is
 exhausted or if the zero flag fails the repeat condition. These two cases
-can be distinguished by using either the 
+can be distinguished by using either the
 <A HREF="Jcc.htm">JCXZ</A> instruction, or by using
-the conditional jumps that test the zero flag (<A HREF="Jcc.htm">JZ</A>, 
-<A HREF="Jcc.htm">JNZ</A>, and 
+the conditional jumps that test the zero flag (<A HREF="Jcc.htm">JZ</A>,
+<A HREF="Jcc.htm">JNZ</A>, and
 <A HREF="Jcc.htm">JNE</A>).
 
 <H2>Flags Affected</H2>
 
-ZF by REP <A HREF="CMPS.htm">CMPS</A> and REP 
+ZF by REP <A HREF="CMPS.htm">CMPS</A> and REP
 <A HREF="SCAS.htm">SCAS</A> as described above
 
 <H2>Protected Mode Exceptions</H2>
@@ -194,7 +194,7 @@ executed; refer to the descriptions of the string instructions themselves
 
 <H2>Notes</H2>
 
-Not all input/output ports can handle the rate at which the REP 
+Not all input/output ports can handle the rate at which the REP
 <A HREF="INS.htm">INS</A>
 and REP <A HREF="OUTS.htm">OUTS</A> instructions execute.
 <P>

--- a/RET.htm
+++ b/RET.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode RET</TITLE>
 </HEAD>
@@ -167,9 +167,9 @@ OUTER-PRIVILEGE-LEVEL:
 <H2>Description</H2>
 
 RET transfers control to a return address located on the stack. The
-address is usually placed on the stack by a 
+address is usually placed on the stack by a
 <A HREF="CALL.htm">CALL</A> instruction, and the
-return is made to the instruction that follows the 
+return is made to the instruction that follows the
 <A HREF="CALL.htm">CALL</A>.
 <P>
 The optional numeric parameter to RET gives the number of stack bytes

--- a/SAHF.htm
+++ b/SAHF.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SAHF</TITLE>
 </HEAD>

--- a/SAL.htm
+++ b/SAL.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SAL</TITLE>
 </HEAD>
@@ -81,7 +81,7 @@ C1   /5 ib      SHR r/m32,imm8    3/7     Unsigned divide r/m dword by 2,
                                           imm8 times
 </PRE>
 
-Not the same division as 
+Not the same division as
 <A HREF="IDIV.htm">IDIV</A>; rounding is toward negative infinity.
 
 <H2>Operation</H2>
@@ -133,8 +133,8 @@ to 0.
 SAR and SHR shift the bits of the operand downward. The low-order
 bit is shifted into the carry flag. The effect is to divide the operand by
 2. SAR performs a signed divide with rounding toward negative infinity (not
-the same as 
-<A HREF="IDIV.htm">IDIV</A>); 
+the same as
+<A HREF="IDIV.htm">IDIV</A>);
 the high-order bit remains the same. SHR performs an
 unsigned divide; the high-order bit is set to 0.
 <P>

--- a/SBB.htm
+++ b/SBB.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SBB</TITLE>
 </HEAD>

--- a/SCAS.htm
+++ b/SCAS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SCAS</TITLE>
 </HEAD>
@@ -66,9 +66,9 @@ operand validates ES segment addressability and determines the data type.
 Load the correct index value into DI or EDI before executing SCAS.
 <P>
 After the comparison is made, the destination register is automatically
-updated. If the direction flag is 0 
+updated. If the direction flag is 0
 (<A HREF="CLD.htm">CLD</A> was executed), the destination
-register is incremented; if the direction flag is 1 
+register is incremented; if the direction flag is 1
 (<A HREF="STD.htm">STD</A> was executed), it
 is decremented. The increments or decrements are by 1 if bytes are compared,
 by 2 if words are compared, or by 4 if doublewords are compared.
@@ -77,10 +77,10 @@ SCASB, SCASW, and SCASD are synonyms for the byte, word and
 doubleword SCAS instructions that don't require operands. They are
 simpler to code, but provide no type or segment checking.
 <P>
-SCAS can be preceded by the 
-<A HREF="REP.htm">REPE</A> or 
+SCAS can be preceded by the
+<A HREF="REP.htm">REPE</A> or
 <A HREF="REP.htm">REPNE</A> prefix for a block search
-of CX or ECX bytes or words. Refer to the 
+of CX or ECX bytes or words. Refer to the
 <A HREF="REP.htm">REP</A> instruction for further
 details.
 

--- a/SETcc.htm
+++ b/SETcc.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SETcc</TITLE>
 </HEAD>

--- a/SGDT.htm
+++ b/SGDT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SGDT</TITLE>
 </HEAD>

--- a/SHLD.htm
+++ b/SHLD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SHLD</TITLE>
 </HEAD>

--- a/SHRD.htm
+++ b/SHRD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SHRD</TITLE>
 </HEAD>

--- a/SLDT.htm
+++ b/SLDT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SLDT</TITLE>
 </HEAD>

--- a/SMSW.htm
+++ b/SMSW.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SMSW</TITLE>
 </HEAD>

--- a/STC.htm
+++ b/STC.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode STC</TITLE>
 </HEAD>

--- a/STD.htm
+++ b/STD.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode STD</TITLE>
 </HEAD>

--- a/STI.htm
+++ b/STI.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode STI</TITLE>
 </HEAD>
@@ -32,14 +32,14 @@ IF := 1
 STI sets the interrupt flag to 1. The 80386 then responds to external
 interrupts after executing the next instruction if the next instruction
 allows the interrupt flag to remain enabled. If external interrupts are
-disabled and you code STI, 
+disabled and you code STI,
 <A HREF="RET.htm">RET</A> (such as at the end of a subroutine),
-the 
-<A HREF="RET.htm">RET</A> 
+the
+<A HREF="RET.htm">RET</A>
 is allowed to execute before external interrupts are recognized.
-Also, if external interrupts are disabled and you code STI, 
+Also, if external interrupts are disabled and you code STI,
 <A HREF="CLI.htm">CLI</A>, then
-external interrupts are not recognized because the 
+external interrupts are not recognized because the
 <A HREF="CLI.htm">CLI</A> instruction clears
 the interrupt flag during its execution.
 

--- a/STOS.htm
+++ b/STOS.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode STOS</TITLE>
 </HEAD>
@@ -73,11 +73,11 @@ type. Load the correct index value into the destination register before
 executing STOS.
 <P>
 After the transfer is made, DI is automatically updated. If the direction
-flag is 0 
-(<A HREF="CLD.htm">CLD</A> was executed), DI is incremented; 
+flag is 0
+(<A HREF="CLD.htm">CLD</A> was executed), DI is incremented;
 if the direction flag is
-1 
-(<A HREF="STD.htm">STD</A> was executed), 
+1
+(<A HREF="STD.htm">STD</A> was executed),
 DI is decremented. DI is incremented or decremented by
 1 if a byte is stored, by 2 if a word is stored, or by 4 if a doubleword is
 stored.
@@ -86,9 +86,9 @@ STOSB, STOSW, and STOSD are synonyms for the byte, word, and doubleword STOS
 instructions, that do not require an operand. They are simpler to use, but
 provide no type or segment checking.
 <P>
-STOS can be preceded by the 
+STOS can be preceded by the
 <A HREF="REP.htm">REP</A> prefix for a block fill of CX or ECX bytes,
-words, or doublewords. Refer to the 
+words, or doublewords. Refer to the
 <A HREF="REP.htm">REP</A> instruction for further details.
 
 <H2>Flags Affected</H2>

--- a/STR.htm
+++ b/STR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode STR</TITLE>
 </HEAD>

--- a/SUB.htm
+++ b/SUB.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode SUB</TITLE>
 </HEAD>

--- a/TEST.htm
+++ b/TEST.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode TEST</TITLE>
 </HEAD>

--- a/VERR.htm
+++ b/VERR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode VERR</TITLE>
 </HEAD>

--- a/WAIT.htm
+++ b/WAIT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode WAIT</TITLE>
 </HEAD>

--- a/XCHG.htm
+++ b/XCHG.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode XCHG</TITLE>
 </HEAD>
@@ -41,7 +41,7 @@ SRC := temp
 
 XCHG exchanges two operands. The operands can be in either order. If a
 memory operand is involved, BUS LOCK is asserted for the duration of the
-exchange, regardless of the presence or absence of the 
+exchange, regardless of the presence or absence of the
 <A HREF="LOCK.htm">LOCK</A> prefix or of the
 value of the IOPL.
 

--- a/XLAT.htm
+++ b/XLAT.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode XLAT</TITLE>
 </HEAD>

--- a/XOR.htm
+++ b/XOR.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Opcode AAA</TITLE>
 </HEAD>
@@ -84,4 +84,3 @@ fault
 <B>up:</B> <A HREF="c17.htm">
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B><A HREF="XLAT.htm"> XLAT/XLATB  Table Look-up Translation</A>
-

--- a/app.htm
+++ b/app.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- APPENDICES</TITLE>
 </HEAD>
@@ -18,4 +18,3 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">Table of Contents</A>
 </BODY>
-

--- a/appa.htm
+++ b/appa.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Appendix A</TITLE>
 </HEAD>
@@ -30,113 +30,113 @@ character, a lowercase letter, specifies the type of operand.
 <H3>Codes for Addressing Method</H3>
 
 <DL>
-<DT>A  
+<DT>A
 <DD>Direct address; the instruction has no modR/M byte; the address of the
    operand is encoded in the instruction; no base register, index register,
    or scaling factor can be applied; e.g., far <A HREF="JMP.htm">JMP</A> (EA).
 
-<DT>C  
-<DD>The reg field of the modR/M byte selects a control register; e.g., 
+<DT>C
+<DD>The reg field of the modR/M byte selects a control register; e.g.,
 <A HREF="MOVRS.htm">MOV</A>
    (0F20, 0F22).
 
-<DT>D  
-<DD>The reg field of the modR/M byte selects a debug register; e.g., 
+<DT>D
+<DD>The reg field of the modR/M byte selects a debug register; e.g.,
 <A HREF="MOVRS.htm">MOV</A>
    (0F21,0F23).
 
-<DT>E  
+<DT>E
 <DD>A modR/M byte follows the opcode and specifies the operand. The operand
    is either a general register or a memory address. If it is a memory
    address, the address is computed from a segment register and any of the
    following values: a base register, an index register, a scaling factor,
    a displacement.
 
-<DT>F  
+<DT>F
 <DD>Flags Register.
 
-<DT>G  
-<DD>The reg field of the modR/M byte selects a general register; e.g., 
+<DT>G
+<DD>The reg field of the modR/M byte selects a general register; e.g.,
 <A HREF="ADD.htm">ADD</A>
    (00).
 
-<DT>I  
+<DT>I
 <DD>Immediate data. The value of the operand is encoded in subsequent bytes
    of the instruction.
 
-<DT>J  
+<DT>J
 <DD>The instruction contains a relative offset to be added to the
-   instruction pointer register; e.g., <A HREF="JMP.htm">JMP</A> short, 
+   instruction pointer register; e.g., <A HREF="JMP.htm">JMP</A> short,
 <A HREF="LOOP.htm">LOOP</A>.
 
-<DT>M  
-<DD>The modR/M byte may refer only to memory; e.g., 
-<A HREF="BOUND.htm">BOUND</A>, <A HREF="LGS.htm">LES</A>, 
+<DT>M
+<DD>The modR/M byte may refer only to memory; e.g.,
+<A HREF="BOUND.htm">BOUND</A>, <A HREF="LGS.htm">LES</A>,
 <A HREF="LGS.htm">LDS</A>, <A HREF="LGS.htm">LSS</A>,
 <A HREF="LGS.htm">LFS</A>, <A HREF="LGS.htm">LGS</A>.
 
-<DT>O  
+<DT>O
 <DD>The instruction has no modR/M byte; the offset of the operand is coded as
    a word or double word (depending on address size attribute) in the
    instruction. No base register, index register, or scaling factor can be
    applied; e.g., <A HREF="MOV.htm">MOV</A> (A0-A3).
 
-<DT>R  
+<DT>R
 <DD>The mod field of the modR/M byte may refer only to a general register;
    e.g., <A HREF="MOV.htm">MOV</A> (0F20-0F24, 0F26).
 
-<DT>S  
-<DD>The reg field of the modR/M byte selects a segment register; e.g., 
+<DT>S
+<DD>The reg field of the modR/M byte selects a segment register; e.g.,
 <A HREF="MOV.htm">MOV</A>
    (8C,8E).
 
-<DT>T  
-<DD>The reg field of the modR/M byte selects a test register; e.g., 
+<DT>T
+<DD>The reg field of the modR/M byte selects a test register; e.g.,
 <A HREF="MOVRS.htm">MOV</A>
    (0F24,0F26).
 
-<DT>X  
-<DD>Memory addressed by DS:SI; e.g., <A HREF="MOVS.htm">MOVS</A>, 
-<A HREF="CMPS.htm">CMPS</A>, 
-<A HREF="OUTS.htm">OUTS</A>, 
-<A HREF="LODS.htm">LODS</A>, 
+<DT>X
+<DD>Memory addressed by DS:SI; e.g., <A HREF="MOVS.htm">MOVS</A>,
+<A HREF="CMPS.htm">CMPS</A>,
+<A HREF="OUTS.htm">OUTS</A>,
+<A HREF="LODS.htm">LODS</A>,
 <A HREF="SCAS.htm">SCAS</A>.
 
-<DT>Y  
-<DD>Memory addressed by ES:DI; e.g., 
-<A HREF="MOVS.htm">MOVS</A>, 
-<A HREF="CMPS.htm">CMPS</A>, 
-<A HREF="INS.htm">INS</A>, 
+<DT>Y
+<DD>Memory addressed by ES:DI; e.g.,
+<A HREF="MOVS.htm">MOVS</A>,
+<A HREF="CMPS.htm">CMPS</A>,
+<A HREF="INS.htm">INS</A>,
 <A HREF="STOS.htm">STOS</A>.
 </DL>
 
 <H3>Codes for Operant Type</H3>
 
 <DL>
-<DT>a 
+<DT>a
 <DD> Two one-word operands in memory or two double-word operands in memory,
-   depending on operand size attribute (used only by 
+   depending on operand size attribute (used only by
 <A HREF="BOUND.htm">BOUND</A>)
 
-<DT>b  
+<DT>b
 <DD>Byte (regardless of operand size attribute)
 
-<DT>c  
+<DT>c
 <DD>Byte or word, depending on operand size attribute.
 
-<DT>d  
+<DT>d
 <DD>Double word (regardless of operand size attribute)
 
-<DT>p  
+<DT>p
 <DD>32-bit or 48-bit pointer, depending on operand size attribute.
 
-<DT>s  
+<DT>s
 <DD>Six-byte pseudo-descriptor
 
-<DT>v  
+<DT>v
 <DD>Word or double word, depending on operand size attribute.
 
-<DT>w  
+<DT>w
 <DD>Word (regardless of operand size attribute)
 </DL>
 

--- a/appb.htm
+++ b/appb.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 17</TITLE>
 </HEAD>

--- a/appc.htm
+++ b/appc.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Appendix C</TITLE>
 </HEAD>

--- a/appd.htm
+++ b/appd.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Appendix D</TITLE>
 </HEAD>

--- a/c01.htm
+++ b/c01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 01</TITLE>
 </HEAD>

--- a/c02.htm
+++ b/c02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 02</TITLE>
 </HEAD>

--- a/c03.htm
+++ b/c03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 03</TITLE>
 </HEAD>
@@ -26,7 +26,7 @@ The descriptions in this chapter assume that the 80386 is operating in
 protected mode with 32-bit addressing in effect; however, all instructions
 discussed are also available when 16-bit addressing is in effect in
 protected mode, real mode, or virtual 8086 mode. For any differences of
-operation that exist in the various modes , refer to 
+operation that exist in the various modes , refer to
 <A HREF="c13.htm">Chapter 13</A>
    ,
 <A HREF="c14.htm">Chapter 14</A>
@@ -34,7 +34,7 @@ operation that exist in the various modes , refer to
 <A HREF="c15.htm">Chapter 15</A>
    .
 <P>
-The instruction dictionary in 
+The instruction dictionary in
 <A HREF="c17.htm">Chapter 17</A>
    contains more detailed
 descriptions of all instructions, including encoding, operation, timing,

--- a/c04.htm
+++ b/c04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 04</TITLE>
 </HEAD>

--- a/c05.htm
+++ b/c05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 05</TITLE>
 </HEAD>
@@ -25,7 +25,7 @@ memory) in two steps:
      designers.
 </UL>
 These translations are performed in a way that is not visible to
-applications programmers. 
+applications programmers.
 <A HREF="c05.htm#fig5-1">Figure 5-1</A>
   illustrates the two translations at a
 high level of abstraction.
@@ -35,7 +35,7 @@ high level of abstraction.
   and the remainder of this chapter present a simplified view of
 the 80386 addressing mechanism. In reality, the addressing mechanism also
 includes memory protection features. For the sake of simplicity, however,
-the subject of protection is taken up in another chapter, 
+the subject of protection is taken up in another chapter,
 <A HREF="c06.htm">Chapter 6</A>.
 <P>
 <A NAME="fig5-1">

--- a/c06.htm
+++ b/c06.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 06</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s05_03.htm">5.3  Combining Segment and Page Translation</A><BR>
 <B>next:</B> <A HREF="s06_01.htm">6.1  Why Protection?</A>
 <P>
@@ -24,7 +24,7 @@ Table of Contents</A><BR>
 <P>
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s05_03.htm">5.3  Combining Segment and Page Translation</A><BR>
 <B>next:</B> <A HREF="s06_01.htm">6.1  Why Protection?</A>
 </BODY>

--- a/c07.htm
+++ b/c07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 07</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <P>
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s06_05.htm">6.5  Combining Page and Segment Protection</A><BR>
 <B>next:</B> <A HREF="s07_01.htm">7.1  Task State Segment</A>
 <P>
@@ -57,7 +57,7 @@ other task-management features:
 <P>
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s06_05.htm">6.5  Combining Page and Segment Protection</A><BR>
 <B>next:</B> <A HREF="s07_01.htm">7.1  Task State Segment</A>
 </BODY>

--- a/c08.htm
+++ b/c08.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 08</TITLE>
 </HEAD>

--- a/c09.htm
+++ b/c09.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 09</TITLE>
 </HEAD>
@@ -14,7 +14,7 @@ Table of Contents</A><BR>
 <H1>Chapter 9  Exceptions and Interrupts</H1>
 <P>
 Interrupts and exceptions are special kinds of control transfer; they work
-somewhat like unprogrammed 
+somewhat like unprogrammed
 <A HREF="CALL.htm">CALL</A>s. They alter the normal program flow to
 handle external events or to report errors or exceptional conditions. The
 difference between interrupts and exceptions is that interrupts are used to
@@ -37,10 +37,10 @@ exceptions:
 <LI>Processor detected. These are further classified as faults, traps,
          and aborts.
 
-<LI>Programmed. The instructions 
-<A HREF="INT.htm">INTO</A>, 
-<A HREF="INT.htm">INT</A> 3, 
-<A HREF="INT.htm">INT n</A>, and 
+<LI>Programmed. The instructions
+<A HREF="INT.htm">INTO</A>,
+<A HREF="INT.htm">INT</A> 3,
+<A HREF="INT.htm">INT n</A>, and
 <A HREF="BOUND.htm">BOUND</A> can
          trigger exceptions. These instructions are often called "software
          interrupts", but the processor handles them as exceptions.

--- a/c10.htm
+++ b/c10.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 10</TITLE>
 </HEAD>

--- a/c11.htm
+++ b/c11.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 11</TITLE>
 </HEAD>

--- a/c12.htm
+++ b/c12.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 12</TITLE>
 </HEAD>

--- a/c13.htm
+++ b/c13.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 13</TITLE>
 </HEAD>
@@ -23,6 +23,6 @@ Table of Contents</A><BR>
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
 <B>prev:</B> <A HREF="s12_03.htm">12.3  Debug Exceptions</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="s13_01.htm">13.1  80286 Code Executes as a Subset of the 80386</A>
 </BODY>

--- a/c14.htm
+++ b/c14.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 14</TITLE>
 </HEAD>
@@ -21,8 +21,8 @@ In effect, the architecture of the 80386 in this mode is almost identical
 to that of the 8086, 8088, 80186, and 80188. To a programmer, an 80386 in
 real-address mode appears as a high-speed 8086 with extensions to the
 instruction set and registers. The principal features of this architecture
-are defined in 
-<A HREF="c02.htm">Chapters 2</A> and 
+are defined in
+<A HREF="c02.htm">Chapters 2</A> and
 <A HREF="c03.htm">3</A>.
 <P>
 This chapter discusses certain additional topics that complete the system

--- a/c15.htm
+++ b/c15.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 15</TITLE>
 </HEAD>

--- a/c16.htm
+++ b/c16.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 16</TITLE>
 </HEAD>
@@ -19,7 +19,7 @@ Table of Contents</A><BR>
 The 80386 running in protected mode is a 32-bit microprocessor, but it is
 designed to support 16-bit processing at three levels:
 <OL>
-<LI>Executing 8086/80286 16-bit programs efficiently with complete 
+<LI>Executing 8086/80286 16-bit programs efficiently with complete
       compatibility.
 
 <LI>Mixing 16-bit modules with 32-bit modules.
@@ -27,8 +27,8 @@ designed to support 16-bit processing at three levels:
 <LI>Mixing 16-bit and 32-bit addresses and operands within one module.
 </OL>
 The first level of support for 16-bit programs has already been discussed
-in <A HREF="c13.htm">Chapter 13</A>, 
-<A HREF="c14.htm">Chapter 14</A>, 
+in <A HREF="c13.htm">Chapter 13</A>,
+<A HREF="c14.htm">Chapter 14</A>,
 and <A HREF="c15.htm">Chapter 15</A>. This chapter shows how 16-bit
 and 32-bit modules can cooperate with one another, and how one module can
 utilize both 16-bit and 32-bit operands and addressing.
@@ -44,7 +44,7 @@ has these characteristics:
 </UL>
 A pure 32-bit module has these characteristics:
 <UL>
-<LI>Segments may occupy more than 64 Kilobytes (zero bytes to 4 
+<LI>Segments may occupy more than 64 Kilobytes (zero bytes to 4
    gigabytes).
 
 <LI>Data items are either 8 bits or 32 bits wide.
@@ -94,7 +94,7 @@ features.
 Table of Contents</A><BR>
 <B>prev:</B>
 <A HREF="s15_07.htm">15.7  Differences From 80286 Real-Address Mode</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="s16_01.htm">
 16.1  How the 80386 Implements 16-Bit and 32-Bit Features</A>
 </BODY>

--- a/c17.htm
+++ b/c17.htm
@@ -1,15 +1,15 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 17</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s16_04.htm">
 16.4  Transferring Control Among Mixed Code Segments></A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="s17_01.htm">17.1  Operand-Size and Address-Size Attributes</A>
 <P>
 <HR>
@@ -128,9 +128,9 @@ summary of exceptions generated.
 <P>
 <B>up:</B> <A HREF="toc.htm">
 Table of Contents</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="s16_04.htm">
 16.4  Transferring Control Among Mixed Code Segments></A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="s17_01.htm">17.1  Operand-Size and Address-Size Attributes</A>
 </BODY>

--- a/s01_01.htm
+++ b/s01_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 1.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c01.htm">
 Chapter 1 -- Introduction to the 80386</A><BR>
-<B>prev:</B> <A HREF="c01.htm">Chapter 1 -- Introduction to the 80386</A><BR> 
+<B>prev:</B> <A HREF="c01.htm">Chapter 1 -- Introduction to the 80386</A><BR>
 <B>next:</B> <A HREF="s01_02.htm">1.2 Related Literature</A>
 <P>
 <HR>
@@ -18,7 +18,7 @@ This book presents the architecture of the 80386 in five parts:
 <LI><A HREF="PII.htm">Part II -- Systems Programming</A>
 <LI><A HREF="PIII.htm">Part III -- Compatibility</A>
 <LI><A HREF="PIV.htm">Part IV -- Instruction Set</A>
-<LI><A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/APP.htm">Appendices</A>    
+<LI><A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/APP.htm">Appendices</A>
 </UL>
 
 These divisions are determined in part by the architecture itself and in
@@ -83,13 +83,13 @@ software in protected mode form Part II. Part III explains real-address
 mode and V86 mode, as well as how to execute a mix of 32-bit and 16-bit
 programs.
 <DL>
-<DT>Available in All Modes 
+<DT>Available in All Modes
 <DD><A HREF="PI.htm">Part I -- Applications Programming</A>
 
-<DT>Available in Protected Mode Only 
+<DT>Available in Protected Mode Only
 <DD><A HREF="PII.htm">Part II -- Systems Programming</A>
 
-<DT>Compatibility Modes 
+<DT>Compatibility Modes
 <DD><A HREF="PIII.htm">Part III -- Compatibility</A>
 </DL>
 
@@ -98,14 +98,14 @@ programs.
 This part presents those aspects of the architecture that are customarily
 used by applications programmers.
 <P>
-<H4><A HREF="c02.htm">Chapter 2 -- Basic Programming Model:</A></H4> 
+<H4><A HREF="c02.htm">Chapter 2 -- Basic Programming Model:</A></H4>
 Introduces the models of memory
 organization. Defines the data types. Presents the register set used by
 applications. Introduces the stack. Explains string operations. Defines the
 parts of an instruction. Explains addressing calculations. Introduces
 interrupts and exceptions as they may apply to applications programming.
 <P>
-<H4><A HREF="c03.htm">Chapter 3 -- Application Instruction Set:</A></H4> 
+<H4><A HREF="c03.htm">Chapter 3 -- Application Instruction Set:</A></H4>
 Surveys the instructions commonly
 used for applications programming. Considers instructions in functionally
 related groups; for example, string instructions are considered in one
@@ -121,57 +121,57 @@ used by programmers who write operating systems, device drivers, debuggers,
 and other software that supports applications programs in the protected mode
 of the 80386.
 <P>
-<H4><A HREF="c04.htm">Chapter 4 -- Systems Architecture:</A></H4> 
-Surveys the features of the 80386 that 
+<H4><A HREF="c04.htm">Chapter 4 -- Systems Architecture:</A></H4>
+Surveys the features of the 80386 that
 are used by systems programmers. Introduces the remaining registers and data
 structures of the 80386 that were not discussed in Part I. Introduces the
 systems-oriented instructions in the context of the registers and data
 structures they support. Points to the chapter where each register, data
 structure, and instruction is considered in more detail.
 
-<H4><A HREF="c05.htm">Chapter 5 -- Memory Management:</A></H4> 
+<H4><A HREF="c05.htm">Chapter 5 -- Memory Management:</A></H4>
 Presents details of the data structures,
 registers, and instructions that support virtual memory and the concepts of
 segmentation and paging. Explains how systems designers can choose a model
 of memory organization ranging from completely linear ("flat") to fully
 paged and segmented.
 
-<H4><A HREF="c06.htm">Chapter 6 -- Protection:</A></H4> 
+<H4><A HREF="c06.htm">Chapter 6 -- Protection:</A></H4>
 Expands on the memory management features of the
 80386 to include protection as it applies to both segments and pages.
 Explains the implementation of privilege rules, stack switching, pointer
 validation, user and supervisor modes. Protection aspects of multitasking
 are deferred until the following chapter.
 
-<H4><A HREF="c07.htm">Chapter 7 -- Multitasking:</A></H4> 
-Explains how the hardware of the 80386 
+<H4><A HREF="c07.htm">Chapter 7 -- Multitasking:</A></H4>
+Explains how the hardware of the 80386
 supports
 multitasking with context-switching operations and intertask protection.
 
-<H4><A HREF="c08.htm">Chapter 8 -- Input/Output:</A></H4> 
+<H4><A HREF="c08.htm">Chapter 8 -- Input/Output:</A></H4>
 Reveals the I/O features of the 80386, including
 I/O instructions, protection as it relates to I/O, and the I/O permission
 map.
 
-<H4><A HREF="c09.htm">Chapter 9 -- Exceptions and Interrupts:</A></H4> 
+<H4><A HREF="c09.htm">Chapter 9 -- Exceptions and Interrupts:</A></H4>
 Explains the basic interrupt
 mechanisms of the 80386. Shows how interrupts and exceptions relate to
 protection. Discusses all possible exceptions, listing causes and including
 information needed to handle and recover from the exception.
 
-<H4><A HREF="c10.htm">Chapter 10 -- Initialization:</A></H4> 
+<H4><A HREF="c10.htm">Chapter 10 -- Initialization:</A></H4>
 Defines the condition of the processor after
 RESET or power-up. Explains how to set up registers, flags, and data
 structures for either real-address mode or protected mode. Contains an
 example of an initialization program.
 
-<H4><A HREF="c11.htm">Chapter 11 -- Coprocessing and Multiprocessing:</A></H4> 
+<H4><A HREF="c11.htm">Chapter 11 -- Coprocessing and Multiprocessing:</A></H4>
 Explains the instructions
 and flags that support a numerics coprocessor and multiple CPUs with shared
 memory.
 
-<H4><A HREF="c12.htm">Chapter 12 -- Debugging:</A></H4> 
-Tells how to use the debugging registers of 
+<H4><A HREF="c12.htm">Chapter 12 -- Debugging:</A></H4>
+Tells how to use the debugging registers of
 the 80386.
 
 
@@ -191,23 +191,23 @@ addition, 32-bit and 16-bit modules and individual 32-bit and 16-bit
 operations can be mixed in protected mode.
 <P>
 <H4>
-<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code:</A></H4> 
+<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code:</A></H4>
 In its protected mode,
 the 80386 can execute complete 80286 protected-mode systems, because 80286
 capabilities are a subset of 80386 capabilities.
 
-<H4><A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode:</A></H4> 
+<H4><A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode:</A></H4>
 Explains the real mode of the 80386
 CPU. In this mode the 80386 appears as a fast real-mode 80286 or fast 8086
 enhanced with additional instructions.
 
-<H4><A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode:</A></H4> 
+<H4><A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode:</A></H4>
 The 80386 can switch rapidly between its
 protected mode and V86 mode, giving it the ability to multiprogram 8086
 programs along with "native mode" 32-bit programs.
 
-<H4><A HREF="c16.htm">Chapter 16 -- Mixing 16-Bit and 32-Bit Code:</A></H4> 
-Even within a program or 
+<H4><A HREF="c16.htm">Chapter 16 -- Mixing 16-Bit and 32-Bit Code:</A></H4>
+Even within a program or
 task,
 the 80386 can mix 16-bit and 32-bit modules. Furthermore, any given module
 can utilize both 16-bit and 32-bit operands and addresses.
@@ -237,4 +237,3 @@ Chapter 1 -- Introduction to the 80386</A><BR>
 <B>prev:</B> <A HREF="c01.htm">Chapter 1 -- Introduction to the 80386</A><BR>
 <B>next:</B> <A HREF="s01_02.htm">1.2 Related Literature</A>
 </BODY>
-

--- a/s01_02.htm
+++ b/s01_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 1.2</TITLE>
 </HEAD>

--- a/s01_03.htm
+++ b/s01_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 1.3</TITLE>
 </HEAD>
@@ -23,14 +23,14 @@ manual.
 <H2>1.3.1  Data-Structure Formats</H2>
 In illustrations of data structures in memory, smaller addresses appear at
 the lower-right part of the figure; addresses increase toward the left and
-upwards. Bit positions are numbered from right to left. 
+upwards. Bit positions are numbered from right to left.
 <A HREF="s01_03.htm#fig1-1">Figure 1-1</A>
- 
+
 illustrates this convention.
 
 <H2>1.3.2  Undefined Bits and Software Compatibility</H2>
 In many register and memory layout descriptions, certain bits are marked as
-undefined. When bits are marked as undefined (as illustrated in 
+undefined. When bits are marked as undefined (as illustrated in
 <A HREF="s01_03.htm#fig1-1">Figure 1-1</A>
   ), it is essential for compatibility with future processors that
 software treat these bits as undefined. Software should follow these
@@ -97,11 +97,11 @@ label: prefix mnemonic argument1, argument2, argument3
 where:
 <UL>
 <LI> A <TT>label</TT> is an identifier that is followed by a colon.
-<LI> A <TT>prefix</TT> is an optional reserved 
+<LI> A <TT>prefix</TT> is an optional reserved
 name for one of the instruction prefixes.
-<LI> A <TT>mnemonic</TT> is a reserved name for a class 
+<LI> A <TT>mnemonic</TT> is a reserved name for a class
 of instruction opcodes that have the same function.
-<LI> The operands <TT>argument1</TT>, <TT>argument2</TT>, and 
+<LI> The operands <TT>argument1</TT>, <TT>argument2</TT>, and
 <TT>argument3</TT> are optional. There
 may be from zero to three operands, depending on the opcode.  When
 present, they take the form of either literals or identifiers for data

--- a/s02_01.htm
+++ b/s02_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.1</TITLE>
 </HEAD>
@@ -42,7 +42,7 @@ In a "flat" model of memory organization, the applications programmer sees
 a single array of up to 2^(32) bytes (4 gigabytes). While the physical
 memory can contain up to 4 gigabytes, it is usually much smaller; the
 processor maps the 4 gigabyte flat space onto the physical address space by
-the address translation mechanisms described in 
+the address translation mechanisms described in
 <A HREF="c05.htm">Chapter 5</A>
    . Applications
 programmers do not need to know the details of the mapping.
@@ -57,7 +57,7 @@ In a segmented model of memory organization, the address space as viewed by
 an applications program (called the logical address space) is a much larger
 space of up to 2^(46) bytes (64 terabytes). The processor maps the 64
 terabyte logical address space onto the physical address space (up to 4
-gigabytes ) by the address translation mechanisms described in 
+gigabytes ) by the address translation mechanisms described in
 <A HREF="c05.htm">Chapter 5</A>
    .
 Applications programmers do not need to know the details of this mapping.
@@ -68,10 +68,10 @@ length. Each of these linear subspaces is called a segment. A segment is a
 unit of contiguous address space. Segment sizes may range from one byte up
 to a maximum of 2^(32) bytes (4 gigabytes).
 <P>
-A complete pointer in this address space consists of two parts (see 
+A complete pointer in this address space consists of two parts (see
 <A HREF="s02_02.htm#fig2-1">Figure 2-1</A>
   ):
-<OL> 
+<OL>
 <LI>A segment selector, which is a 16-bit field that identifies a
 segment.
 <LI>An offset, which is a 32-bit ordinal that addresses to the byte level

--- a/s02_02.htm
+++ b/s02_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.2</TITLE>
 </HEAD>
@@ -38,9 +38,9 @@ called the high word.
 Each byte within a doubleword has its own address, and the smallest of the
 addresses is the address of the doubleword. The byte at this lowest address
 contains the eight least significant bits of the doubleword, while the byte
-at the highest address contains the eight most significant bits. 
+at the highest address contains the eight most significant bits.
 <A HREF="s02_02.htm#fig2-3">Figure 2-3</A>
- 
+
 illustrates the arrangement of bytes within words anddoublewords.
 <P>
 Note that words need not be aligned at even-numbered addresses and

--- a/s02_03.htm
+++ b/s02_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.3</TITLE>
 </HEAD>

--- a/s02_04.htm
+++ b/s02_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.4</TITLE>
 </HEAD>

--- a/s02_05.htm
+++ b/s02_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.5</TITLE>
 </HEAD>

--- a/s02_06.htm
+++ b/s02_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 2.6</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c02.htm">
 Chapter 2 -- Basic Programming Model</A><BR>
 <B>prev:</B> <A HREF="s02_05.htm">2.5  Operand Selection</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A><BR>
 <P>
 <HR>
@@ -29,7 +29,7 @@ interrupt is generally independent of the currently executing program.
 <P>
 Application programmers are not normally concerned with servicing
 interrupts. More information on interrupts for systems programmers may be
-found in 
+found in
 <A HREF="c09.htm">Chapter 9</A>
    . Certain exceptions , however, are of interest to
 applications programmers, and many operating systems give applications
@@ -40,30 +40,30 @@ the exception mechanism of the 80386.
 Table 2-2 highlights the exceptions that may be of interest to applications
 programmers.
 <UL>
-<LI> A divide error exception results when the instruction 
-<A HREF="DIV.htm">DIV</A> or 
+<LI> A divide error exception results when the instruction
+<A HREF="DIV.htm">DIV</A> or
 <A HREF="IDIV.htm">IDIV</A> is
 executed with a zero denominator or when the quotient is too large for
-the destination operand . (Refer to 
+the destination operand . (Refer to
 <A HREF="c03.htm">Chapter 3</A>
-for a discussion of <A HREF="DIV.htm">DIV</A>  
+for a discussion of <A HREF="DIV.htm">DIV</A>
 and <A HREF="IDIV.htm">IDIV</A>.)
 <LI> The debug exception may be reflected back to an applications program
 if it results from the trap flag (TF).
-<LI> A breakpoint exception results when the instruction 
+<LI> A breakpoint exception results when the instruction
 <A HREF="INT.htm">INT 3</A> is executed.
 This instruction is used by some debuggers to stop program execution at
 specific points.
-<LI> An overflow exception results when the 
+<LI> An overflow exception results when the
 <A HREF="INT.htm">INTO</A> instruction is executed
 and the OF (overflow) flag is set (after an arithmetic operation that
-set the OF flag ) . (Refer to 
+set the OF flag ) . (Refer to
 <A HREF="c03.htm">Chapter 3</A>
    for a discussion of <A HREF="INT.htm">INTO</A>) .
-<LI> A bounds check exception results when the 
+<LI> A bounds check exception results when the
 <A HREF="BOUND.htm">BOUND</A> instruction is
 executed and the array index it checks falls outside the bounds of the
-array . (Refer to 
+array . (Refer to
 <A HREF="c03.htm">Chapter 3</A>
    for a discussion of the <A HREF="BOUND.htm">BOUND</A> instruction. )
 <LI> Invalid opcodes may be used by some applications to extend the
@@ -79,10 +79,10 @@ The instruction <A HREF="INT.htm">INT</A> generates an interrupt whenever it is 
 processor treats this interrupt as an exception. The effects of this
 interrupt (and the effects of all other exceptions) are determined by
 exception handler routines provided by the application program or as part of
-the systems software (provided by systems programmers). The 
+the systems software (provided by systems programmers). The
 <A HREF="INT.htm">INT</A> instruction
-itself is discussed in 
-<A HREF="c03.htm">Chapter 3</A>. Refer to 
+itself is discussed in
+<A HREF="c03.htm">Chapter 3</A>. Refer to
 <A HREF="c09.htm">Chapter 9</A> for a more complete
 description of exceptions.
 <PRE>

--- a/s03_01.htm
+++ b/s03_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.1</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c03.htm">
 Chapter 3 -- Applications Instruction Set</A><BR>
 <B>prev:</B>
-<A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A><BR> 
+<A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A><BR>
 <B>next:</B> <A HREF="s03_02.htm">3.2  Binary Arithmetic Instructions</A>
 <P>
 <HR>
@@ -23,12 +23,12 @@ architecture. They fall into the following classes:
 </OL>
 
 <H2>3.1.1  General-Purpose Data Movement Instructions</H2>
-<A HREF="MOV.htm">MOV</A> (Move) 
+<A HREF="MOV.htm">MOV</A> (Move)
 transfers a byte, word, or doubleword from the source operand to
-the destination operand. The 
+the destination operand. The
 <A HREF="MOV.htm">MOV</A> instruction is useful for transferring data
 along any of these paths
-There are also variants of 
+There are also variants of
 <A HREF="MOV.htm">MOV</A> that operate on segment registers.  These
 are covered in a later section of this chapter:
 <UL>
@@ -38,71 +38,71 @@ are covered in a later section of this chapter:
 <LI> Immediate data to a register
 <LI> Immediate data to a memory
 </UL>
-The <A HREF="MOV.htm">MOV</A> instruction 
+The <A HREF="MOV.htm">MOV</A> instruction
 cannot move from memory to memory or from segment
 register to segment register are not allowed. Memory-to-memory moves can be
-performed, however, by the string move instruction 
+performed, however, by the string move instruction
 <A HREF="MOVS.htm">MOVS</A>.
 <P>
-<A HREF="XCHG.htm">XCHG</A> 
+<A HREF="XCHG.htm">XCHG</A>
 (Exchange) swaps the contents of two operands. This instruction takes
-the place of three <A HREF="MOV.htm">MOV</A> instructions. 
+the place of three <A HREF="MOV.htm">MOV</A> instructions.
 It does not require a temporary
 location to save the contents of one operand while load the other is being
-loaded. 
-<A HREF="XCHG.htm">XCHG</A> 
+loaded.
+<A HREF="XCHG.htm">XCHG</A>
 is especially useful for implementing semaphores or similar
 data structures for process synchronization.
 <P>
-The <A HREF="XCHG.htm">XCHG</A> instruction can swap two byte operands, 
+The <A HREF="XCHG.htm">XCHG</A> instruction can swap two byte operands,
 two word operands, or two
-doubleword operands. The operands for the 
+doubleword operands. The operands for the
 <A HREF="XCHG.htm">XCHG</A> instruction may be two
 register operands, or a register operand with a memory operand. When used
-with a memory operand, 
-<A HREF="XCHG.htm">XCHG</A> automatically activates the 
-<A HREF="LOCK.htm">LOCK</A> signal. (Refer to 
+with a memory operand,
+<A HREF="XCHG.htm">XCHG</A> automatically activates the
+<A HREF="LOCK.htm">LOCK</A> signal. (Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for more information on the bus lock. )
 
 <H2>3.1.2  Stack Manipulation Instructions</H2>
-<A HREF="PUSH.htm">PUSH</A> (Push) 
+<A HREF="PUSH.htm">PUSH</A> (Push)
 decrements the stack pointer (ESP), then transfers the source
-operand to the top of stack indicated by ESP (see 
-<A HREF="s03_01.htm#fig3-1">Figure 3-1</A>). 
+operand to the top of stack indicated by ESP (see
+<A HREF="s03_01.htm#fig3-1">Figure 3-1</A>).
 <A HREF="PUSH.htm">PUSH</A> is
 often used to place parameters on the stack before calling a procedure; it
 is also the basic means of storing temporary variables on the stack. The
-<A HREF="PUSH.htm">PUSH</A> instruction operates on memory operands, 
+<A HREF="PUSH.htm">PUSH</A> instruction operates on memory operands,
 immediate operands, and register operands (including segment registers).
 <P>
-<A HREF="PUSHA.htm">PUSHA</A> (Push All Registers) 
+<A HREF="PUSHA.htm">PUSHA</A> (Push All Registers)
 saves the contents of the eight general
-registers on the stack (see 
+registers on the stack (see
 <A HREF="s03_01.htm#fig3-2">Figure 3-2</A>). This instruction simplifies
 procedure calls by reducing the number of instructions required to retain
 the contents of the general registers for use in a procedure. The processor
 pushes the general registers on the stack in the following order: EAX, ECX,
 EDX, EBX, the initial value of ESP before EAX was pushed, EBP, ESI, and
-EDI. 
-<A HREF="PUSHA.htm">PUSHA</A> is complemented by the 
+EDI.
+<A HREF="PUSHA.htm">PUSHA</A> is complemented by the
 <A HREF="POPA.htm">POPA</A> instruction.
 <P>
-<A HREF="POP.htm">POP</A> (Pop) 
+<A HREF="POP.htm">POP</A> (Pop)
 transfers the word or doubleword at the current top of stack
 (indicated by ESP) to the destination operand, and then increments ESP to
-point to the new top of stack. See 
-<A HREF="s03_01.htm#fig3-3">Figure 3-3</A>. 
+point to the new top of stack. See
+<A HREF="s03_01.htm#fig3-3">Figure 3-3</A>.
 <A HREF="POP.htm">POP</A> moves information from
 the stack to a general register, or to memory
-There are also a variant of 
+There are also a variant of
 <A HREF="POP.htm">POP</A> that operates on segment registers. This
 is covered in a later section of this chapter.
 <P>
-<A HREF="POPA.htm">POPA</A> (Pop All Registers) 
+<A HREF="POPA.htm">POPA</A> (Pop All Registers)
 restores the registers saved on the stack by
-<A HREF="PUSHA.htm">PUSHA</A>, except that it ignores the saved value of ESP. 
-See 
+<A HREF="PUSHA.htm">PUSHA</A>, except that it ignores the saved value of ESP.
+See
 <A HREF="s03_01.htm#fig3-4">Figure 3-4</A>.
 <P>
 <A NAME="fig3-1">
@@ -174,41 +174,41 @@ the sign bit of the smaller item. This kind of conversion, illustrated by
 <P>
 There are two classes of type conversion instructions:
 <OL>
-<LI>The forms <A HREF="CWD.htm">CWD</A>, 
-<A HREF="CWD.htm">CDQ</A>, 
-<A HREF="CBW.htm">CBW</A>, and 
+<LI>The forms <A HREF="CWD.htm">CWD</A>,
+<A HREF="CWD.htm">CDQ</A>,
+<A HREF="CBW.htm">CBW</A>, and
 <A HREF="CBW.htm">CWDE</A> which operate only on data in the EAX register.
-<LI>The forms 
-<A HREF="MOVSX.htm">MOVSX</A> and 
+<LI>The forms
+<A HREF="MOVSX.htm">MOVSX</A> and
 <A HREF="MOVZX.htm">MOVZX</A>, which permit one operand to be in any
 general register while permitting the other operand to be in memory or
 in a register.
 </OL>
-<A HREF="CWD.htm">CWD</A> (Convert Word to Doubleword) and 
+<A HREF="CWD.htm">CWD</A> (Convert Word to Doubleword) and
 <A HREF="CWD.htm">CDQ</A> (Convert Doubleword to Quad-Word)
-double the size of the source operand. 
+double the size of the source operand.
 <A HREF="CWD.htm">CWD</A> extends the sign of the
-word in register AX throughout register DX. 
+word in register AX throughout register DX.
 <A HREF="CWD.htm">CDQ</A> extends the sign of the
-doubleword in EAX throughout EDX. 
+doubleword in EAX throughout EDX.
 <A HREF="CWD.htm">CWD</A> can be used to produce a doubleword
-dividend from a word before a word division, and 
+dividend from a word before a word division, and
 <A HREF="CWD.htm">CDQ</A> can be used to produce
 a quad-word dividend from a doubleword before doubleword division.
 <P>
-<A HREF="CBW.htm">CBW</A> (Convert Byte to Word) 
+<A HREF="CBW.htm">CBW</A> (Convert Byte to Word)
 extends the sign of the byte in register AL
 throughout AX.
 <P>
-<A HREF="CBW.htm">CWDE</A> (Convert Word to Doubleword Extended) 
+<A HREF="CBW.htm">CWDE</A> (Convert Word to Doubleword Extended)
 extends the sign of the word in
 register AX throughout EAX.
 <P>
-<A HREF="MOVSX.htm">MOVSX</A> (Move with Sign Extension) 
+<A HREF="MOVSX.htm">MOVSX</A> (Move with Sign Extension)
 sign-extends an 8-bit value to a 16-bit
 value and a 8- or 16-bit value to 32-bit value.
 <P>
-<A HREF="MOVZX.htm">MOVZX</A> (Move with Zero Extension) 
+<A HREF="MOVZX.htm">MOVZX</A> (Move with Zero Extension)
 extends an 8-bit value to a 16-bit value
 and an 8- or 16-bit value to 32-bit value by inserting high-order zeros.
 <P>
@@ -292,7 +292,7 @@ and an 8- or 16-bit value to 32-bit value by inserting high-order zeros.
 <P>
 <B>up:</B> <A HREF="c03.htm">
 Chapter 3 -- Applications Instruction Set</A><BR>
-<B>prev:</B> 
-<A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A><BR> 
+<B>prev:</B>
+<A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A><BR>
 <B>next:</B> <A HREF="s03_02.htm">3.2  Binary Arithmetic Instructions</A>
 </BODY>

--- a/s03_02.htm
+++ b/s03_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.2</TITLE>
 </HEAD>

--- a/s03_03.htm
+++ b/s03_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.3</TITLE>
 </HEAD>
@@ -27,45 +27,45 @@ These instructions operate only on the AL or AH registers. Most utilize the
 AF flag.
 
 <H2>3.3.1  Packed BCD Adjustment Instructions</H2>
-<A HREF="DAA.htm">DAA</A> (Decimal Adjust after Addition) 
+<A HREF="DAA.htm">DAA</A> (Decimal Adjust after Addition)
 adjusts the result of adding two valid
-packed decimal operands in AL. 
+packed decimal operands in AL.
 <A HREF="DAA.htm">DAA</A> must always follow the addition of two
 pairs of packed decimal numbers (one digit in each half-byte) to obtain a
 pair of valid packed decimal digits as results. The carry flag is set if
 carry was needed.
 <P>
-<A HREF="DAS.htm">DAS</A> (Decimal Adjust after Subtraction) 
+<A HREF="DAS.htm">DAS</A> (Decimal Adjust after Subtraction)
 adjusts the result of subtracting
-two valid packed decimal operands in AL. 
+two valid packed decimal operands in AL.
 <A HREF="DAS.htm">DAS</A> must always follow the
 subtraction of one pair of packed decimal numbers (one digit in each half-
 byte) from another to obtain a pair of valid packed decimal digits as
 results. The carry flag is set if a borrow was needed.
 
 <H2>3.3.2  Unpacked BCD Adjustment Instructions</H2>
-<A HREF="AAA.htm">AAA</A> (ASCII Adjust after Addition) 
+<A HREF="AAA.htm">AAA</A> (ASCII Adjust after Addition)
 changes the contents of register AL to a
-valid unpacked decimal number, and zeros the top 4 bits. 
+valid unpacked decimal number, and zeros the top 4 bits.
 <A HREF="AAA.htm">AAA</A> must always
 follow the addition of two unpacked decimal operands in AL. The carry flag
 is set and AH is incremented if a carry is necessary.
 <P>
-<A HREF="AAS.htm">AAS</A> (ASCII Adjust after Subtraction) 
+<A HREF="AAS.htm">AAS</A> (ASCII Adjust after Subtraction)
 changes the contents of register AL to
-a valid unpacked decimal number, and zeros the top 4 bits. 
+a valid unpacked decimal number, and zeros the top 4 bits.
 <A HREF="AAS.htm">AAS</A> must always
 follow the subtraction of one unpacked decimal operand from another in AL.
 The carry flag is set and AH decremented if a borrow is necessary.
 <P>
-<A HREF="AAM.htm">AAM</A> (ASCII Adjust after Multiplication) 
+<A HREF="AAM.htm">AAM</A> (ASCII Adjust after Multiplication)
 corrects the result of a
-multiplication of two valid unpacked decimal numbers. 
+multiplication of two valid unpacked decimal numbers.
 <A HREF="AAM.htm">AAM</A> must always follow
 the multiplication of two decimal numbers to produce a valid decimal result.
 The high order digit is left in AH, the low order digit in AL.
 <P>
-<A HREF="AAD.htm">AAD</A> (ASCII Adjust before Division) 
+<A HREF="AAD.htm">AAD</A> (ASCII Adjust before Division)
 modifies the numerator in AH and AL to
 prepare for the division of two valid unpacked decimal operands so that the
 quotient produced by the division will be a valid unpacked decimal number.

--- a/s03_04.htm
+++ b/s03_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.4</TITLE>
 </HEAD>
@@ -21,22 +21,22 @@ The group of logical instructions includes:
 <LI> Byte set on condition
 </UL>
 <H2>3.4.1  Boolean Operation Instructions</H2>
-The logical operations are <A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
-<A HREF="XOR.htm">XOR</A>, and 
+The logical operations are <A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
+<A HREF="XOR.htm">XOR</A>, and
 <A HREF="NOT.htm">NOT</A>.
 <P>
-<A HREF="NOT.htm">NOT</A> (Not) 
+<A HREF="NOT.htm">NOT</A> (Not)
 inverts the bits in the specified operand to form a one's
-complement of the operand. The 
+complement of the operand. The
 <A HREF="NOT.htm">NOT</A> instruction is a unary operation that
-uses a single operand in a register or memory. 
+uses a single operand in a register or memory.
 <A HREF="NOT.htm">NOT</A> has no effect on the
 flags.
 <P>
-The 
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, and 
+The
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>, and
 <A HREF="XOR.htm">XOR</A> instructions perform the standard logical operations
 "and", "(inclusive) or", and "exclusive or". These instructions can use the
 following combinations of operands:
@@ -46,9 +46,9 @@ following combinations of operands:
 <LI> An immediate operand with either a general register operand or a
 memory operand.
 </UL>
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, and 
-<A HREF="XOR.htm">XOR</A> clear OF and CF, leave AF undefined, 
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>, and
+<A HREF="XOR.htm">XOR</A> clear OF and CF, leave AF undefined,
 and update SF, ZF, and PF.
 
 <H2>3.4.2  Bit Test and Modify Instructions</H2>
@@ -81,10 +81,10 @@ may be either in a register or in memory. The ZF flag is set if the entire
 word is zero (no set bits are found); ZF is cleared if a one-bit is found.
 If no set bit is found, the value of the destination register is undefined.
 <P>
-<A HREF="BSF.htm">BSF</A> (Bit Scan Forward) 
+<A HREF="BSF.htm">BSF</A> (Bit Scan Forward)
 scans from low-order to high-order (starting from bit index zero).
 <P>
-<A HREF="BSR.htm">BSR</A> (Bit Scan Reverse) 
+<A HREF="BSR.htm">BSR</A> (Bit Scan Reverse)
 scans from high-order to low-order (starting from
 bit index 15 of a word or index 31 of a doubleword).
 
@@ -118,58 +118,58 @@ a multibit shift, however, the content of OF is always undefined.
 <P>
 The shift instructions provide a convenient way to accomplish division or
 multiplication by binary power. Note however that division of signed numbers
-by shifting right is not the same kind of division performed by the 
+by shifting right is not the same kind of division performed by the
 <A HREF="IDIV.htm">IDIV</A> instruction.
 <P>
-<A HREF="SAL.htm">SAL</A> (Shift Arithmetic Left) 
+<A HREF="SAL.htm">SAL</A> (Shift Arithmetic Left)
 shifts the destination byte, word, or
 doubleword operand left by one or by the number of bits specified in the
 count operand (an immediate value or the value contained in CL). The
 processor shifts zeros in from the right (low-order) side of the operand as
-bits exit from the left (high-order) side. See 
+bits exit from the left (high-order) side. See
 <A HREF="s03_04.htm#fig3-6">Figure 3-6</A>.
 <P>
-<A HREF="SAL.htm">SHL</A> (Shift Logical Left) 
+<A HREF="SAL.htm">SHL</A> (Shift Logical Left)
 is a synonym for <A HREF="SAL.htm">SAL</A> (refer to <A HREF="SAL.htm">SAL</A>).
 <P>
-<A HREF="SAL.htm">SHR</A> (Shift Logical Right) shifts the destination byte, 
+<A HREF="SAL.htm">SHR</A> (Shift Logical Right) shifts the destination byte,
 word, or doubleword
 operand right by one or by the number of bits specified in the count operand
 (an immediate value or the value contained in CL). The processor shifts
 zeros in from the left side of the operand as bits exit from the right side.
-See 
+See
 <A HREF="s03_04.htm#fig3-7">Figure 3-7</A>.
 <P>
-<A HREF="SAL.htm">SAR</A> (Shift Arithmetic Right) 
+<A HREF="SAL.htm">SAR</A> (Shift Arithmetic Right)
 shifts the destination byte, word, or
 doubleword operand to the right by one or by the number of bits specified in
 the count operand (an immediate value or the value contained in CL). The
 processor preserves the sign of the operand by shifting in zeros on the left
 (high-order) side if the value is positive or by shifting by ones if the
-value is negative. See 
+value is negative. See
 <A HREF="s03_04.htm#fig3-8">Figure 3-8</A>.
 <P>
 Even though this instruction can be used to divide integers by a power of
-two, the type of division is not the same as that produced by the 
+two, the type of division is not the same as that produced by the
 <A HREF="IDIV.htm">IDIV</A>
-instruction. The quotient of 
+instruction. The quotient of
 <A HREF="IDIV.htm">IDIV</A> is rounded toward zero, whereas the
-"quotient" of 
-<A HREF="SAL.htm">SAR</A> is rounded toward negative infinity. 
+"quotient" of
+<A HREF="SAL.htm">SAR</A> is rounded toward negative infinity.
 This difference is
-apparent only for negative numbers. For example, when 
+apparent only for negative numbers. For example, when
 <A HREF="IDIV.htm">IDIV</A> is used to divide
--9 by 4, the result is -2 with a remainder of -1. If 
+-9 by 4, the result is -2 with a remainder of -1. If
 <A HREF="SAL.htm">SAR</A> is used to shift
 -9 right by two bits, the result is -3. The "remainder" of this kind of
-division is +3; however, the 
+division is +3; however, the
 <A HREF="SAL.htm">SAR</A> instruction stores only the high-order bit
 of the remainder (in CF).
 <P>
-The code sequence in 
+The code sequence in
 <A HREF="s03_04.htm#fig3-9">Figure 3-9</A>
-  produces the same result as 
-<A HREF="IDIV.htm">IDIV</A> for any M = 2^(N), where 0 < N < 32. 
+  produces the same result as
+<A HREF="IDIV.htm">IDIV</A> for any M = 2^(N), where 0 < N < 32.
 This sequence takes about 12 to 18 clocks,
 depending on whether the jump is taken; if ECX contains M, the corresponding
 <A HREF="IDIV.htm">IDIV</A> ECX instruction will take about 43 clocks.
@@ -265,19 +265,19 @@ operand. CF is set to the value of the last bit shifted out of the
 destination operand. SF, ZF, and PF are set according to the value of the
 result. OF and AF are left undefined.
 <P>
-<A HREF="SHLD.htm">SHLD</A> (Shift Left Double) 
+<A HREF="SHLD.htm">SHLD</A> (Shift Left Double)
 shifts bits of the R/M field to the left, while
 shifting high-order bits from the Reg field into the R/M field on the right
-(see 
-<A HREF="s03_04.htm#fig3-10">Figure 3-10</A>). 
+(see
+<A HREF="s03_04.htm#fig3-10">Figure 3-10</A>).
 The result is stored back into the R/M operand. The Reg
 field is not modified.
 <P>
-<A HREF="SHRD.htm">SHRD</A> (Shift Right Double) 
+<A HREF="SHRD.htm">SHRD</A> (Shift Right Double)
 shifts bits of the R/M field to the right, while
 shifting low-order bits from the Reg field into the R/M field on the left
-(see 
-<A HREF="s03_04.htm#fig3-11">Figure 3-11</A>). 
+(see
+<A HREF="s03_04.htm#fig3-11">Figure 3-11</A>).
 The result is stored back into the R/M operand. The Reg
 field is not modified.
 
@@ -289,7 +289,7 @@ rotated. Bits rotated out of an operand are not lost as in a shift, but are
 Rotates affect only the carry and overflow flags. CF may act as an
 extension of the operand in two of the rotate instructions, allowing a bit
 to be isolated and then tested by a conditional jump instruction (<A HREF="Jcc.htm">JC</A> or
-<A HREF="Jcc.htm">JNC</A>). 
+<A HREF="Jcc.htm">JNC</A>).
 CF always contains the value of the last bit rotated out, even if the
 instruction does not use this bit as an extension of the rotated operand.
 <P>
@@ -298,38 +298,38 @@ In single-bit rotates, OF is set if the operation changes the high-order
 value, OF is cleared. On multibit rotates, the value of OF is always
 undefined.
 <P>
-<A HREF="RCL.htm">ROL</A> (Rotate Left) 
+<A HREF="RCL.htm">ROL</A> (Rotate Left)
 rotates the byte, word, or doubleword destination operand
 left by one or by the number of bits specified in the count operand (an
 immediate value or the value contained in CL). For each rotation specified,
 the high-order bit that exits from the left of the operand returns at the
-right to become the new low-order bit of the operand. See 
+right to become the new low-order bit of the operand. See
 <A HREF="s03_04.htm#fig3-12">Figure 3-12</A>.
 <P>
-<A HREF="RCL.htm">ROR</A> (Rotate Right) 
+<A HREF="RCL.htm">ROR</A> (Rotate Right)
 rotates the byte, word, or doubleword destination
 operand right by one or by the number of bits specified in the count operand
 (an immediate value or the value contained in CL). For each rotation
 specified, the low-order bit that exits from the right of the operand
 returns at the left to become the new high-order bit of the operand.
-See 
+See
 <A HREF="s03_04.htm#fig3-13">Figure 3-13</A>.
 <P>
-<A HREF="RCL.htm">RCL</A> (Rotate Through Carry Left) 
+<A HREF="RCL.htm">RCL</A> (Rotate Through Carry Left)
 rotates bits in the byte, word, or
 doubleword destination operand left by one or by the number of bits
 specified in the count operand (an immediate value or the value contained in
 CL).
 <P>
-This instruction differs from 
+This instruction differs from
 <A HREF="RCL.htm">ROL</A> in that it treats CF as a high-order
 one-bit extension of the destination operand. Each high-order bit that exits
 from the left side of the operand moves to CF before it returns to the
-operand as the low-order bit on the next rotation cycle. See 
+operand as the low-order bit on the next rotation cycle. See
 <A HREF="s03_04.htm#fig3-14">Figure 3-14</A>
   .
 <P>
-<A HREF="RCL.htm">RCR</A> (Rotate Through Carry Right) 
+<A HREF="RCL.htm">RCR</A> (Rotate Through Carry Right)
 rotates bits in the byte, word, or
 doubleword destination operand right by one or by the number of bits
 specified in the count operand (an immediate value or the value contained in
@@ -338,7 +338,7 @@ CL).
 This instruction differs from <A HREF="RCL.htm">ROR</A> in that it treats CF as a low-order
 one-bit extension of the destination operand. Each low-order bit that exits
 from the right side of the operand moves to CF before it returns to the
-operand as the high-order bit on the next rotation cycle. See 
+operand as the high-order bit on the next rotation cycle. See
 <A HREF="s03_04.htm#fig3-15">Figure 3-15</A>
   .
 <P>
@@ -450,8 +450,8 @@ JA    BltLoop
 This loop is simple yet allows the data to be moved in 32-bit pieces for
 the highest possible performance. Without a double shift, the best that can
 be achieved is 16 bits per loop iteration by using a 32-bit shift and
-replacing the 
-<A HREF="XCHG.htm">XCHG</A> with a 
+replacing the
+<A HREF="XCHG.htm">XCHG</A> with a
 <A HREF="RCL.htm">ROR</A> by 16 to swap high and low order parts of
 registers. A more general loop than shown above would require some extra
 masking on the first doubleword moved (before the main loop), and on the
@@ -624,25 +624,25 @@ the 16 conditions defined by the status flags. The byte may be in memory or
 may be a one-byte general register. These instructions are especially useful
 for implementing Boolean expressions in high-level languages such as Pascal.
 <P>
-<A HREF="SETcc.htm">SETcc</A> (Set Byte on Condition cc) 
+<A HREF="SETcc.htm">SETcc</A> (Set Byte on Condition cc)
 set a byte to one if condition cc is true;
 sets the byte to zero otherwise. Refer to Appendix D for a definition of
 the possible conditions.
 
 <H2>3.4.6  Test Instruction</H2>
-<A HREF="TEST.htm">TEST</A> (Test) 
+<A HREF="TEST.htm">TEST</A> (Test)
 performs the logical "and" of the two operands, clears OF and
 CF, leaves AF undefined, and updates SF, ZF, and PF. The flags can be tested
 by conditional control transfer instructions or by the byte-set-on-condition
 instructions. The operands may be doublewords, words, or bytes.
 <P>
-The difference between 
-<A HREF="TEST.htm">TEST</A> and 
-<A HREF="AND.htm">AND</A> is that <A HREF="TEST.htm">TEST</A> 
-does not alter the destination operand. 
-<A HREF="TEST.htm">TEST</A> differs from <A HREF="BT.htm">BT</A> in that 
+The difference between
+<A HREF="TEST.htm">TEST</A> and
+<A HREF="AND.htm">AND</A> is that <A HREF="TEST.htm">TEST</A>
+does not alter the destination operand.
+<A HREF="TEST.htm">TEST</A> differs from <A HREF="BT.htm">BT</A> in that
 <A HREF="TEST.htm">TEST</A> is useful for testing
-the value of multiple bits in one operations, whereas 
+the value of multiple bits in one operations, whereas
 <A HREF="BT.htm">BT</A> tests a single bit.
 <P>
 <HR>

--- a/s03_05.htm
+++ b/s03_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.5</TITLE>
 </HEAD>

--- a/s03_06.htm
+++ b/s03_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.6</TITLE>
 </HEAD>
@@ -64,10 +64,10 @@ if one, they are decremented. The amount of the increment or decrement is
 1, 2, or 4 depending on the size of the string element.
 
 <H2>3.6.1  Repeat Prefixes</H2>
-The repeat prefixes 
-<A HREF="REP.htm">REP</A> (Repeat While ECX Not Zero), 
+The repeat prefixes
+<A HREF="REP.htm">REP</A> (Repeat While ECX Not Zero),
 <A HREF="REP.htm">REPE/REPZ</A> (Repeat
-While Equal/Zero), and 
+While Equal/Zero), and
 <A HREF="REP.htm">REPNE/REPNZ</A> (Repeat While Not Equal/Not Zero) specify
 repeated operation of a string primitive. This form of iteration allows the
 CPU to process strings much faster than would be possible with a regular
@@ -86,16 +86,16 @@ on strings of arbitrary length, without affecting interrupt response.
 <P>
 All three prefixes causes the hardware to automatically repeat the
 associated string primitive until ECX=0. The differences among the repeat
-prefixes have to do with the second termination condition. 
+prefixes have to do with the second termination condition.
 <A HREF="REP.htm">REPE/REPZ</A> and
-<A HREF="REP.htm">REPNE/REPNZ</A> are used exclusively with the 
-<A HREF="SCAS.htm">SCAS</A> (Scan String) and 
+<A HREF="REP.htm">REPNE/REPNZ</A> are used exclusively with the
+<A HREF="SCAS.htm">SCAS</A> (Scan String) and
 <A HREF="CMPS.htm">CMPS</A>
 (Compare String) primitives. When these prefixes are used, repetition of the
 next instruction depends on the zero flag (ZF) as well as the ECX register.
 ZF does not require initialization before execution of a repeated string
-instruction, because both 
-<A HREF="SCAS.htm">SCAS</A> and 
+instruction, because both
+<A HREF="SCAS.htm">SCAS</A> and
 <A HREF="CMPS.htm">CMPS</A> set ZF according to the results of
 the comparisons they make. The differences are summarized in the
 accompanying table.
@@ -124,25 +124,25 @@ be used as general-purpose registers.
 <P>
 When ESI and EDI are used in string primitives, they are automatically
 incremented or decremented after to operation. The direction flag determines
-whether they are incremented or decremented. The instruction 
+whether they are incremented or decremented. The instruction
 <A HREF="CLD.htm">CLD</A> puts zero
-in DF, causing the index registers to be incremented; the instruction 
+in DF, causing the index registers to be incremented; the instruction
 <A HREF="STD.htm">STD</A>
 puts one in DF, causing the index registers to be decremented. Programmers
 should always put a known value in DF before using string instructions in a
 procedure.
 
 <H2>3.6.3  String Instructions</H2>
-<A HREF="MOVS.htm">MOVS</A> (Move String) 
+<A HREF="MOVS.htm">MOVS</A> (Move String)
 moves the string element pointed to by ESI to the
-location pointed to by EDI. 
-<A HREF="MOVS.htm">MOVSB</A> operates on byte elements, 
-<A HREF="MOVS.htm">MOVSW</A> operates on word elements, and 
+location pointed to by EDI.
+<A HREF="MOVS.htm">MOVSB</A> operates on byte elements,
+<A HREF="MOVS.htm">MOVSW</A> operates on word elements, and
 <A HREF="MOVS.htm">MOVSD</A> operates on doublewords. The destination segment
 register cannot be overridden by a segment override prefix, but the source
 segment register can be overridden.
 <P>
-The <A HREF="MOVS.htm">MOVS</A> instruction, when accompanied by the 
+The <A HREF="MOVS.htm">MOVS</A> instruction, when accompanied by the
 <A HREF="REP.htm">REP</A> prefix, operates as a
 memory-to-memory block transfer. To set up for this operation, the program
 must initialize ECX and the register pairs ESI and EDI. ECX specifies the
@@ -154,48 +154,48 @@ DF=1, the program must point these two registers to the last element of the
 source string and to the destination address for the last element,
 respectively.
 <P>
-<A HREF="CMPS.htm">CMPS</A> (Compare Strings) 
+<A HREF="CMPS.htm">CMPS</A> (Compare Strings)
 subtracts the destination string element (at ES:EDI)
 from the source string element (at ESI) and updates the flags AF, SF, PF, CF
 and OF. If the string elements are equal, ZF=1; otherwise, ZF=0. If DF=0,
 the processor increments the memory pointers (ESI and EDI) for the two
-strings. 
-<A HREF="CMPS.htm">CMPSB</A> compares bytes, 
-<A HREF="MOVS.htm">MOVSW</A> compares words, and 
-<A HREF="MOVS.htm">MOVSD</A> compares doublewords. 
+strings.
+<A HREF="CMPS.htm">CMPSB</A> compares bytes,
+<A HREF="MOVS.htm">MOVSW</A> compares words, and
+<A HREF="MOVS.htm">MOVSD</A> compares doublewords.
 The segment register used for the source address can be changed
 with a segment override prefix while the destination segment register
 cannot be overridden.
 <P>
-<A HREF="SCAS.htm">SCAS</A> (Scan String) 
+<A HREF="SCAS.htm">SCAS</A> (Scan String)
 subtracts the destination string element at ES:EDI from
 EAX, AX, or AL and updates the flags AF, SF, ZF, PF, CF and OF. If the
 values are equal, ZF=1; otherwise, ZF=0. If DF=0, the processor increments
-the memory pointer (EDI) for the string. 
-<A HREF="SCAS.htm">SCASB</A> scans bytes; 
-<A HREF="SCAS.htm">SCASW</A> scans words; 
-<A HREF="SCAS.htm">SCASD</A> scans doublewords. 
+the memory pointer (EDI) for the string.
+<A HREF="SCAS.htm">SCASB</A> scans bytes;
+<A HREF="SCAS.htm">SCASW</A> scans words;
+<A HREF="SCAS.htm">SCASD</A> scans doublewords.
 The destination segment register (ES) cannot
 be overridden.
 <P>
-When either the 
-<A HREF="REP.htm">REPE</A> or 
-<A HREF="REP.htm">REPNE</A> prefix modifies either the 
-<A HREF="SCAS.htm">SCAS</A> or 
+When either the
+<A HREF="REP.htm">REPE</A> or
+<A HREF="REP.htm">REPNE</A> prefix modifies either the
+<A HREF="SCAS.htm">SCAS</A> or
 <A HREF="CMPS.htm">CMPS</A>
 primitives, the processor compares the value of the current string element
 with the value in EAX for doubleword elements, in AX for word elements, or
 in AL for byte elements. Termination of the repeated operation depends on
 the resulting state of ZF as well as on the value in ECX.
 <P>
-<A HREF="LODS.htm">LODS</A> (Load String) 
+<A HREF="LODS.htm">LODS</A> (Load String)
 places the source string element at ESI into EAX for
 doubleword strings, into AX for word strings, or into AL for byte strings.
 <A HREF="LODS.htm">LODS</A> increments or decrements ESI according to DF.
 <P>
-<A HREF="STOS.htm">STOS</A> (Store String) 
+<A HREF="STOS.htm">STOS</A> (Store String)
 places the source string element from EAX, AX, or AL
-into the string at ES:DSI. 
+into the string at ES:DSI.
 <A HREF="STOS.htm">STOS</A> increments or decrements EDI according to
 DF.
 <P>

--- a/s03_07.htm
+++ b/s03_07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.7</TITLE>
 </HEAD>
@@ -91,25 +91,25 @@ frames of previous iterations.
 <P>
 By copying only the stack frame pointers of procedures at higher lexical
 levels, <A HREF="ENTER.htm">ENTER</A> makes sure that procedures access only those variables of
-higher lexical levels, not those at parallel lexical levels (see 
+higher lexical levels, not those at parallel lexical levels (see
 <A HREF="s03_07.htm#fig3-17">Figure 3-17</A>
   ).
 <A HREF="s03_07.htm#fig3-18">Figures 3-18</A>
   through 3-21 demonstrate the actions of the <A HREF="ENTER.htm">ENTER</A>
-instruction if the modules shown in 
+instruction if the modules shown in
 <A HREF="s03_07.htm#fig3-17">Figure 3-17</A>
   were to call one another in
 alphabetic order.
 <P>
 Block-structured high-level languages can use the lexical levels defined by
 <A HREF="ENTER.htm">ENTER</A> to control access to the variables of previously nested procedures.
-Referring to 
+Referring to
 <A HREF="s03_07.htm#fig3-17">Figure 3-17</A>
   for example, if PROCEDURE A calls PROCEDURE B
 which, in turn, calls PROCEDURE C, then PROCEDURE C will have access to the
 variables of MAIN and PROCEDURE A, but not PROCEDURE B because they operate
 at the same lexical level. Following is the complete definition of access to
-variables for 
+variables for
 <A HREF="s03_07.htm#fig3-17">Figure 3-17</A>
   .
 <OL>
@@ -129,7 +129,7 @@ MAIN. PROCEDURE D cannot access the variables of PROCEDURE B.
 <A HREF="ENTER.htm">ENTER</A> at the beginning of the MAIN PROGRAM creates dynamic storage space
 for MAIN but copies no pointers. The first and only word in the display
 points to itself because there is no previous value for <A HREF="LEAVE.htm">LEAVE</A> to return to
-EBP. See 
+EBP. See
 <A HREF="s03_07.htm#fig3-18">Figure 3-18</A>
   .
 <P>
@@ -148,7 +148,7 @@ PROCEDURE B with the first word pointing to the previous value of EBP, the
 second word pointing to the value of EBP for MAIN, and the third word
 pointing to the value of EBP for A and the last word pointing to the current
 EBP. B can access variables in A and MAIN by fetching from the display the
-base addresses of the respective dynamic storage areas. See 
+base addresses of the respective dynamic storage areas. See
 <A HREF="s03_07.htm#fig3-20">Figure 3-20</A>
   .
 After PROCEDURE B calls PROCEDURE C, <A HREF="ENTER.htm">ENTER</A> creates a new display for
@@ -158,12 +158,12 @@ pointing to the EBP value for A and the third word pointing to the current
 value of EBP. Because PROCEDURE B and PROCEDURE C have the same lexical
 level, PROCEDURE C is not allowed access to variables in B and therefore
 does not receive a pointer to the beginning of PROCEDURE B's stack frame.
-See 
+See
 <A HREF="s03_07.htm#fig3-21">Figure 3-21</A>
   .
 <P>
 <A HREF="LEAVE.htm">LEAVE</A> (Leave Procedure) reverses the action of the previous <A HREF="ENTER.htm">ENTER</A>
-instruction. The <A HREF="LEAVE.htm">LEAVE</A> instruction does not include any operands. 
+instruction. The <A HREF="LEAVE.htm">LEAVE</A> instruction does not include any operands.
 <A HREF="LEAVE.htm">LEAVE</A>
 copies EBP to ESP to release all stack space allocated to the procedure by
 the most recent <A HREF="ENTER.htm">ENTER</A> instruction. Then <A HREF="LEAVE.htm">LEAVE</A> pops the old value of EBP from

--- a/s03_08.htm
+++ b/s03_08.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.8</TITLE>
 </HEAD>
@@ -17,7 +17,7 @@ state of bits in the flag register.
 
 <H2>3.8.1  Carry and Direction Flag Control Instructions</H2>
 The carry flag instructions are useful in conjunction with
-rotate-with-carry instructions <A HREF="RCL.htm">RCL</A> and 
+rotate-with-carry instructions <A HREF="RCL.htm">RCL</A> and
 <A HREF="RCL.htm">RCR</A>. They can initialize the carry
 flag, CF, to a known state before execution of a rotate that moves the carry
 bit into one end of the rotated operand.
@@ -45,44 +45,44 @@ instructions allow a program to alter the other flag bits with the bit
 manipulation instructions after transferring these flags to the stack or the
 AH register.
 <P>
-The instructions 
-<A HREF="LAHF.htm">LAHF</A> and 
+The instructions
+<A HREF="LAHF.htm">LAHF</A> and
 <A HREF="SAHF.htm">SAHF</A> deal with five of the status flags, which
 are used primarily by the arithmetic and logical instructions.
 <P>
-<A HREF="LAHF.htm">LAHF</A> (Load AH from Flags) 
+<A HREF="LAHF.htm">LAHF</A> (Load AH from Flags)
 copies SF, ZF, AF, PF, and CF to AH bits 7, 6, 4,
-2, and 0, respectively (see 
-<A HREF="s03_08.htm#fig3-22">Figure 3-22</A>). 
+2, and 0, respectively (see
+<A HREF="s03_08.htm#fig3-22">Figure 3-22</A>).
 The contents of the remaining bits
 (5, 3, and 1) are undefined. The flags remain unaffected.
 <P>
-<A HREF="SAHF.htm">SAHF</A> (Store AH into Flags) 
+<A HREF="SAHF.htm">SAHF</A> (Store AH into Flags)
 transfers bits 7, 6, 4, 2, and 0 from AH into
-SF, ZF, AF, PF, and CF, respectively (see 
+SF, ZF, AF, PF, and CF, respectively (see
 <A HREF="s03_08.htm#fig3-22">Figure 3-22</A>).
 <P>
-The 
-<A HREF="PUSHF.htm">PUSHF</A> and 
-<A HREF="POPF.htm">POPF</A> instructions are not only useful for 
+The
+<A HREF="PUSHF.htm">PUSHF</A> and
+<A HREF="POPF.htm">POPF</A> instructions are not only useful for
 storing the flags
 in memory where they can be examined and modified but are also useful for
 preserving the state of the flags register while executing a procedure.
 <P>
-<A HREF="PUSHF.htm">PUSHF</A> (Push Flags) 
+<A HREF="PUSHF.htm">PUSHF</A> (Push Flags)
 decrements ESP by two and then transfers the low-order
 word of the flags register to the word at the top of stack pointed to by ESP
-(see 
-<A HREF="s03_09.htm#fig3-23">Figure 3-23</A>). 
+(see
+<A HREF="s03_09.htm#fig3-23">Figure 3-23</A>).
 The variant <A HREF="PUSHF.htm">PUSHFD</A> decrements ESP by four, then
 transfers both words of the extended flags register to the top of the stack
 pointed to by ESP (the VM and RF flags are not moved, however).
 <P>
-<A HREF="POPF.htm">POPF</A> (Pop Flags) 
+<A HREF="POPF.htm">POPF</A> (Pop Flags)
 transfers specific bits from the word at the top of stack
-into the low-order byte of the flag register (see 
+into the low-order byte of the flag register (see
 <A HREF="s03_09.htm#fig3-23">Figure 3-23</A>), then
-increments ESP by two. The variant 
+increments ESP by two. The variant
 <A HREF="POPF.htm">POPFD</A> transfers specific bits from the
 doubleword at the top of the stack into the extended flags register (the RF
 and VM flags are not changed, however), then increments ESP by four.

--- a/s03_09.htm
+++ b/s03_09.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.9</TITLE>
 </HEAD>
@@ -29,7 +29,7 @@ calculations.
 The 80386 also has features to support emulation of the numerics
 coprocessor when the coprocessor is absent. The software emulation of the
 coprocessor is transparent to application software but requires more time
-for execution . Refer to 
+for execution . Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for more information on coprocessor
 emulation.
@@ -41,7 +41,7 @@ numerics coprocessor uses the escape instructions to perform
 high-performance, high-precision floating point arithmetic that conforms to
 the IEEE floating point standard 754.
 <P>
-<A HREF="WAIT.htm">WAIT</A> (Wait) 
+<A HREF="WAIT.htm">WAIT</A> (Wait)
 is an 80386 instruction that suspends program execution until
 the 80386 CPU detects that the BUSY pin is inactive. This condition
 indicates that the coprocessor has completed its processing task and that

--- a/s03_10.htm
+++ b/s03_10.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.10</TITLE>
 </HEAD>
@@ -54,15 +54,15 @@ segmentation is not apparent to the applications programmer.
 </UL>
 
 <H2>3.10.1  Segment-Register Transfer Instructions</H2>
-The 
-<A HREF="MOV.htm">MOV</A>, 
-<A HREF="POP.htm">POP</A>, and 
+The
+<A HREF="MOV.htm">MOV</A>,
+<A HREF="POP.htm">POP</A>, and
 <A HREF="PUSH.htm">PUSH</A> instructions also serve to load and store segment
 registers. These variants operate similarly to their general-register
-counterparts except that one operand can be a segment register. 
+counterparts except that one operand can be a segment register.
 <A HREF="MOV.htm">MOV</A> cannot
-move segment register to a segment register. Neither 
-<A HREF="POP.htm">POP</A> nor 
+move segment register to a segment register. Neither
+<A HREF="POP.htm">POP</A> nor
 <A HREF="MOV.htm">MOV</A> can place a
 value in the code-segment register CS; only the far control-transfer
 instructions can change CS.
@@ -71,31 +71,31 @@ instructions can change CS.
 The far control-transfer instructions transfer control to a location in
 another segment by changing the content of the CS register.
 <P>
-Direct far <A HREF="JMP.htm">JMP</A>. Direct 
+Direct far <A HREF="JMP.htm">JMP</A>. Direct
 <A HREF="JMP.htm">JMP</A> instructions that specify a target location
 outside the current code segment contain a far pointer. This pointer
 consists of a selector for the new code segment and an offset within the new
 segment.
 <P>
-Indirect far <A HREF="JMP.htm">JMP</A>. Indirect 
+Indirect far <A HREF="JMP.htm">JMP</A>. Indirect
 <A HREF="JMP.htm">JMP</A> instructions that specify a target location
 outside the current code segment use a 48-bit variable to specify the far
 pointer.
 <P>
-Far <A HREF="CALL.htm">CALL</A>. An intersegment 
+Far <A HREF="CALL.htm">CALL</A>. An intersegment
 <A HREF="CALL.htm">CALL</A> places both the value of EIP and CS on the
 stack.
 <P>
-Far <A HREF="RET.htm">RET</A>. An intersegment 
+Far <A HREF="RET.htm">RET</A>. An intersegment
 <A HREF="RET.htm">RET</A> restores the values of both CS and EIP which
-were saved on the stack by the previous intersegment 
+were saved on the stack by the previous intersegment
 <A HREF="CALL.htm">CALL</A> instruction.
 
 <H2>3.10.3  Data Pointer Instructions</H2>
 The data pointer instructions load a pointer (consisting of a segment
 selector and an offset) to a segment register and a general register.
 <P>
-<A HREF="LGS.htm">LDS</A> (Load Pointer Using DS) 
+<A HREF="LGS.htm">LDS</A> (Load Pointer Using DS)
 transfers a pointer variable from the source
 operand to DS and the destination register. The source operand must be a
 memory operand, and the destination operand must be a general register. DS
@@ -111,7 +111,7 @@ STRING_X, and loads the offset of STRING_X into ESI.  Specifying ESI as the
 destination operand is a convenient way to prepare for a string operation on
 a source string that is not in the current data segment.
 <P>
-<A HREF="LGS.htm">LES</A> (Load Pointer Using ES) 
+<A HREF="LGS.htm">LES</A> (Load Pointer Using ES)
 operates identically to <A HREF="LGS.htm">LDS</A> except that ES
 receives the segment selector rather than DS.
 Example:
@@ -123,25 +123,25 @@ DESTINATION_X, and loads the offset of DESTINATION_X into EDI. This
 instruction provides a convenient way to select a destination for a string
 operation if the desired location is not in the current extra segment.
 <P>
-<A HREF="LGS.htm">LFS</A> (Load Pointer Using FS) operates identically to 
+<A HREF="LGS.htm">LFS</A> (Load Pointer Using FS) operates identically to
 <A HREF="LGS.htm">LDS</A> except that FS
 receives the segment selector rather than DS.
 <P>
-<A HREF="LGS.htm">LGS</A> (Load Pointer Using GS) operates identically to 
+<A HREF="LGS.htm">LGS</A> (Load Pointer Using GS) operates identically to
 <A HREF="LGS.htm">LDS</A> except that GS
 receives the segment selector rather than DS.
 <P>
-<A HREF="LGS.htm">LSS</A> (Load Pointer Using SS) operates identically to 
+<A HREF="LGS.htm">LSS</A> (Load Pointer Using SS) operates identically to
 <A HREF="LGS.htm">LDS</A> except that SS
 receives the segment selector rather than DS.  This instruction is
 especially important, because it allows the two registers that identify the
 stack (SS:ESP) to be changed in one uninterruptible operation.  Unlike the
 other instructions which load SS, interrupts are not inhibited at the end
-of the 
-<A HREF="LGS.htm">LSS</A> instruction.  The other instructions (e.g., 
+of the
+<A HREF="LGS.htm">LSS</A> instruction.  The other instructions (e.g.,
 <A HREF="POP.htm">POP</A> SS) inhibit
 interrupts to permit the following instruction to load ESP, thereby forming
-an indivisible load of SS:ESP.  Since both SS and ESP can be loaded by 
+an indivisible load of SS:ESP.  Since both SS and ESP can be loaded by
 <A HREF="LGS.htm">LSS</A>,
 there is no need to inhibit interrupts.
 <P>

--- a/s03_11.htm
+++ b/s03_11.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.11</TITLE>
 </HEAD>
@@ -16,17 +16,17 @@ The following instructions do not fit in any of the previous categories,
 but are nonetheless useful.
 
 <H2>3.11.1  Address Calculation Instruction</H2>
-<A HREF="LEA.htm">LEA</A> (Load Effective Address) 
+<A HREF="LEA.htm">LEA</A> (Load Effective Address)
 transfers the offset of the source operand
 (rather than its value) to the destination operand.  The source operand must
 be a memory operand, and the destination operand must be a general register.
 This instruction is especially useful for initializing registers before the
-execution of the string primitives (ESI, EDI) or the 
+execution of the string primitives (ESI, EDI) or the
 <A HREF="XLAT.htm">XLAT</A> instruction (EBX).
-The 
-<A HREF="LEA.htm">LEA</A> 
+The
+<A HREF="LEA.htm">LEA</A>
 can perform any indexing or scaling that may be needed.
-Example: 
+Example:
 <PRE>
 <A HREF="LEA.htm">LEA</A> EBX, EBCDIC_TABLE
 </PRE>
@@ -34,18 +34,18 @@ Causes the processor to place the address of the starting location of the
 table labeled EBCDIC_TABLE into EBX.
 
 <H2>3.11.2  No-Operation Instruction</H2>
-<A HREF="NOP.htm">NOP</A> (No Operation) 
+<A HREF="NOP.htm">NOP</A> (No Operation)
 occupies a byte of storage but affects nothing but the
 instruction pointer, EIP.
 <P>
 <H2>3.11.3  Translate Instruction</H2>
 <A HREF="XLAT.htm">XLAT</A> (Translate) i
 replaced a byte in the AL register with a byte from a
-user-coded translation table. When 
+user-coded translation table. When
 <A HREF="XLAT.htm">XLAT</A> is executed, AL should have the
-unsigned index to the table addressed by EBX. 
+unsigned index to the table addressed by EBX.
 <A HREF="XLAT.htm">XLAT</A> changes the contents of
-AL from table index to table entry. EBX is unchanged. The 
+AL from table index to table entry. EBX is unchanged. The
 <A HREF="XLAT.htm">XLAT</A> instruction
 is useful for translating from one coding system to another such as from
 ASCII to EBCDIC.  The translate table may be up to 256 bytes long.  The

--- a/s04_01.htm
+++ b/s04_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 4.1</TITLE>
 </HEAD>
@@ -24,57 +24,57 @@ classes:
 <H2>4.1.1  Systems Flags</H2>
 The systems flags of the EFLAGS register control I/O, maskable interrupts,
 debugging, task switching, and enabling of virtual 8086 execution in a
-protected, multitasking environment. These flags are highlighted in 
+protected, multitasking environment. These flags are highlighted in
 <A HREF="s04_01.htm#fig4-1">Figure 4-1</A>
   .
 <DL>
 <DT>
-IF 
+IF
 (Interrupt-Enable Flag, bit 9)
 <DD>
 Setting IF allows the CPU to recognize external (maskable) interrupt
 requests. Clearing IF disables these interrupts. IF has no effect on
-either exceptions or nonmaskable external interrupts . Refer to 
+either exceptions or nonmaskable external interrupts . Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for more details about interrupts .
 <DT>
-NT 
+NT
 (Nested Task, bit 14)
 <DD>
 The processor uses the nested task flag to control chaining of
-interrupted and called tasks. NT influences the operation of the 
+interrupted and called tasks. NT influences the operation of the
 <A HREF="IRET.htm">IRET</A>
-instruction . Refer to 
-<A HREF="c07.htm">Chapter 7</A> and 
+instruction . Refer to
+<A HREF="c07.htm">Chapter 7</A> and
 <A HREF="c09.htm">Chapter 9</A>
 for more information on
 nested tasks.
 <DT>
-RF 
+RF
 (Resume Flag, bit 16)
 <DD>
 The RF flag temporarily disables debug exceptions so that an instruction
 can be restarted after a debug exception without immediately causing
-another debug exception . Refer to 
+another debug exception . Refer to
 <A HREF="c12.htm">Chapter 12</A>
    for details .
 <DT>
-TF 
+TF
 (Trap Flag, bit 8)
 <DD>
 Setting TF puts the processor into single-step mode for debugging. In
 this mode, the CPU automatically generates an exception after each
 instruction, allowing a program to be inspected as it executes each
 instruction. Single-stepping is just one of several debugging features of
-the 80386 . Refer to 
+the 80386 . Refer to
 <A HREF="c12.htm">Chapter 12</A>
    for additional information .
 <DT>
-VM 
+VM
 (Virtual 8086 Mode, bit 17)
 <DD>
 When set, the VM flag indicates that the task is executing an 8086
-program . Refer to 
+program . Refer to
 <A HREF="c14.htm">Chapter 14</A>
    for a detailed discussion of how the 80386
 executes 8086 tasks in a protected, multitasking environment.
@@ -108,31 +108,31 @@ Four registers of the 80386 locate the data structures that control
 segmented memory management:
 <DL>
 <DT>
-GDTR    
+GDTR
 Global Descriptor Table Register
 <DT>
-LDTR    
+LDTR
 Local Descriptor Table Register
 <DD>
 These registers point to the segment descriptor tables GDT and LDT.
-Refer to 
+Refer to
 <A HREF="c05.htm">Chapter 5</A>
    for an explanation of addressing via descriptor
 tables.
 <DT>
-IDTR    
+IDTR
 Interrupt Descriptor Table Register
 <DD>
 This register points to a table of entry points for interrupt handlers
-(the IDT ) . Refer to 
+(the IDT ) . Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for details of the interrupt mechanism .
 <DT>
-TR      
+TR
 Task Register
 <DD>
 This register points to the information needed by the processor to define
-the current task . Refer to 
+the current task . Refer to
 <A HREF="c07.htm">Chapter 7</A>
    for a description of the
 multitasking features of the 80386.
@@ -153,7 +153,7 @@ CR0 contains system control flags, which control or indicate conditions
 that apply to the system as a whole, not to an individual task.
 <DL>
 <DT>
-EM 
+EM
 (Emulation, bit 2)
 <DD>
 EM indicates whether coprocessor functions are to be emulated. Refer to
@@ -161,61 +161,61 @@ EM indicates whether coprocessor functions are to be emulated. Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for details .
 <DT>
-ET 
+ET
 (Extension Type, bit 4)
 <DD>
 ET indicates the type of coprocessor present in the system (80287 or
-80387 ) . Refer to 
-<A HREF="c11.htm">Chapter 11</A> and 
+80387 ) . Refer to
+<A HREF="c11.htm">Chapter 11</A> and
 <A HREF="c10.htm">Chapter 10</A> for details.
 <DT>
-MP 
+MP
 (Math Present, bit 1)
 <DD>
 MP controls the function of the <A HREF="WAIT.htm">WAIT</A> instruction, which is used to
-coordinate a coprocessor . Refer to 
+coordinate a coprocessor . Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for details .
 <DT>
-PE 
+PE
 (Protection Enable, bit 0)
 <DD>
 Setting PE causes the processor to begin executing in protected mode.
-Resetting PE returns to real-address mode . Refer to 
+Resetting PE returns to real-address mode . Refer to
 <A HREF="c14.htm">Chapter 14</A>
    and
 
 <A HREF="c10.htm">Chapter 10</A>
    for more information on changing processor modes .
 <DT>
-PG 
+PG
 (Paging, bit 31)
 <DD>
 PG indicates whether the processor uses page tables to translate linear
-addresses into physical addresses . Refer to 
+addresses into physical addresses . Refer to
 <A HREF="c05.htm">Chapter 5</A>
    for a description
-of page translation; refer to 
+of page translation; refer to
 <A HREF="c10.htm">Chapter 10</A>
    for a discussion of how to set
 PG.
 <DT>
-TS 
+TS
 (Task Switched, bit 3)
 <DD>
 The processor sets TS with every task switch and tests TS when
-interpreting coprocessor instructions . Refer to 
+interpreting coprocessor instructions . Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for details .
 </DL>
 CR2 is used for handling page faults when PG is set. The processor stores
-in CR2 the linear address that triggers the fault . Refer to 
+in CR2 the linear address that triggers the fault . Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for a
 description of page-fault handling.
 <P>
 CR3 is used when PG is set. CR3 enables the processor to locate the page
-table directory for the current task . Refer to 
+table directory for the current task . Refer to
 <A HREF="c05.htm">Chapter 5</A>
    for a description
 of page tables and page translation.
@@ -243,7 +243,7 @@ of page tables and page translation.
 <H2>4.1.4  Debug Register</H2>
 The debug registers bring advanced debugging abilities to the 80386,
 including data breakpoints and the ability to set instruction breakpoints
-without modifying code segments . Refer to 
+without modifying code segments . Refer to
 <A HREF="c12.htm">Chapter 12</A>
    for a complete
 description of formats and usage.
@@ -252,7 +252,7 @@ description of formats and usage.
 The test registers are not a standard part of the 80386 architecture. They
 are provided solely to enable confidence testing of the translation
 lookaside buffer (TLB), the cache used for storing information from page
-tables . 
+tables .
 <A HREF="c12.htm">Chapter 12</A>
    explains how to use these registers .
 <P>

--- a/s04_02.htm
+++ b/s04_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 4.2</TITLE>
 </HEAD>
@@ -7,14 +7,14 @@
 <B>up:</B> <A HREF="c04.htm">
 Chapter 4 -- Systems Architecture</A><BR>
 <B>prev:</B> <A HREF="s04_01.htm">4.1  Systems Registers</A><BR>
-<B>next:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A> 
+<B>next:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A>
 <P>
 <HR>
 <P>
 <H1>4.2  Systems Instructions</H1>
 Systems instructions deal with such functions as:
 <OL>
-<LI> Verification of pointer parameters (refer to 
+<LI> Verification of pointer parameters (refer to
 <A HREF="c06.htm">Chapter 6</A>):
 <UL>
 <LI><A HREF="ARPL.htm">ARPL> -- Adjust RPL</A>
@@ -24,7 +24,7 @@ Systems instructions deal with such functions as:
 <LI><A HREF="VERR.htm">VERW -- Verify for Writing</A>
 </UL>
 <P>
-<LI> Addressing descriptor tables (refer to 
+<LI> Addressing descriptor tables (refer to
 <A HREF="c05.htm">Chapter 5</A>):
 <UL>
 <LI><A HREF="LLDT.htm">LLDT -- Load LDT Register</A>
@@ -33,14 +33,14 @@ Systems instructions deal with such functions as:
 <LI><A HREF="SGDT.htm">SGDT -- Store GDT Register</A>
 </UL>
 <P>
-<LI> Multitasking (refer to 
+<LI> Multitasking (refer to
 <A HREF="c07.htm">Chapter 7</A>):
 <UL>
 <LI><A HREF="LTR.htm">LTR -- Load Task Register</A>
 <LI><A HREF="STR.htm">STR -- Store Task Register</A>
 </UL>
 <P>
-<LI> Coprocessing and Multiprocessing (refer to 
+<LI> Coprocessing and Multiprocessing (refer to
 <A HREF="c11.htm">Chapter 11</A>):
 <UL>
 <LI><A HREF="CLTS.htm">CLTS -- Clear Task-Switched Flag</A>
@@ -49,7 +49,7 @@ Systems instructions deal with such functions as:
 <LI><A HREF="LOCK.htm">LOCK -- Assert Bus-Lock Signal</A>
 </UL>
 <P>
-<LI> Input and Output (refer to 
+<LI> Input and Output (refer to
 <A HREF="c08.htm">Chapter 8</A>):
 <UL>
 <LI><A HREF="IN.htm">IN -- Input</A>
@@ -58,7 +58,7 @@ Systems instructions deal with such functions as:
 <LI><A HREF="OUTS.htm">OUTS -- Output String</A>
 </UL>
 <P>
-<LI> Interrupt control (refer to 
+<LI> Interrupt control (refer to
 <A HREF="c09.htm">Chapter 9</A>):
 <UL>
 <LI><A HREF="CLI.htm">CLI -- Clear Interrupt-Enable Flag</A>
@@ -67,13 +67,13 @@ Systems instructions deal with such functions as:
 <LI><A HREF="SGDT.htm">SIDT -- Store IDT Register</A>
 </UL>
 <P>
-<LI> Debugging (refer to 
+<LI> Debugging (refer to
 <A HREF="c12.htm">Chapter 12</A>):
 <UL>
 <LI><A HREF="MOVRS.htm">MOV -- Move to and from debug registers</A>
 </UL>
 <P>
-<LI> TLB testing (refer to 
+<LI> TLB testing (refer to
 <A HREF="c10.htm">Chapter 10</A>):
 <UL>
 <LI><A HREF="MOVRS.htm">MOV -- Move to and from test registers</A>
@@ -90,7 +90,7 @@ Systems instructions deal with such functions as:
 The instructions <A HREF="SMSW.htm">SMSW</A> and <A HREF="LMSW.htm">LMSW</A>
 are provided for compatibility with the
 80286 processor.  80386 programs access the MSW in CR0 via variants of the
-<A HREF="MOVRS.htm">MOV</A> instruction.  
+<A HREF="MOVRS.htm">MOV</A> instruction.
 <A HREF="HLT.htm">HLT</A> stops the processor until receipt of an INTR or RESET
 signal.
 <P>

--- a/s05_01.htm
+++ b/s05_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 5.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c05.htm">
 Chapter 5 -- Memory Management</A><BR>
-<B>prev:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A><BR> 
+<B>prev:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A><BR>
 <B>next:</B> <A HREF="s05_02.htm">5.2  Page Translation</A>
 <P>
 <HR>
@@ -30,7 +30,7 @@ structures:
 The segment descriptor provides the processor with the data it needs to map
 a logical address into a linear address. Descriptors are created by
 compilers, linkers, loaders, or the operating system, not by applications
-programmers. 
+programmers.
 <A HREF="s05_01.htm#fig5-3">Figure 5-3</A>
   illustrates the two general descriptor formats. All
 types of segment descriptors take one of these formats. Segment-descriptor
@@ -58,15 +58,15 @@ byte; when set, the limit is interpreted in units of 4 Kilobytes.
 TYPE: Distinguishes between various kinds of descriptors.
 <P>
 DPL (Descriptor Privilege Level): Used by the protection mechanism (refer
-to 
+to
 <A HREF="c06.htm">Chapter 6</A>
    ) .
 <P>
 Segment-Present bit: If this bit is zero, the descriptor is not valid for
 use in address transformation; the processor will signal an exception when a
-selector for the descriptor is loaded into a segment register. 
+selector for the descriptor is loaded into a segment register.
 <A HREF="s05_01.htm#fig5-4">Figure 5-4</A>
- 
+
 shows the format of a descriptor when the present-bit is zero. The operating
 system is free to use the locations marked AVAILABLE. Operating systems that
 implement segment-based virtual memory clear the present bit in either of
@@ -159,7 +159,7 @@ Segment descriptors are stored in either of two kinds of descriptor table:
 <LI> A local descriptor table (LDT)
 </UL>
 A descriptor table is simply a memory array of 8-byte entries that contain
-descriptors, as 
+descriptors, as
 <A HREF="s05_01.htm#fig5-5">Figure 5-5</A>
   shows. A descriptor table is variable in length
 and may contain up to 8192 (2^(13)) descriptors. The first entry of the GDT
@@ -168,8 +168,8 @@ and may contain up to 8192 (2^(13)) descriptors. The first entry of the GDT
 The processor locates the GDT and the current LDT in memory by means of the
 GDTR and LDTR registers. These registers store the base addresses of the
 tables in the linear address space and store the segment limits. The
-instructions <A HREF="LGDT.htm">LGDT</A> and 
-<A HREF="SGDT.htm">SGDT</A> give access to the GDTR; the instructions 
+instructions <A HREF="LGDT.htm">LGDT</A> and
+<A HREF="SGDT.htm">SGDT</A> give access to the GDTR; the instructions
 <A HREF="LLDT.htm">LLDT</A>
 and <A HREF="SLDT.htm">SLDT</A> give access to the LDTR.
 <P>
@@ -238,7 +238,7 @@ The selector portion of a logical address identifies a descriptor by
 specifying a descriptor table and indexing a descriptor within that table.
 Selectors may be visible to applications programs as a field within a
 pointer variable, but the values of selectors are usually assigned (fixed
-up) by linkers or linking loaders. 
+up) by linkers or linking loaders.
 <A HREF="s05_01.htm#fig5-6">Figure 5-6</A>
   shows the format of a
 selector.
@@ -308,25 +308,25 @@ avoiding the need to consult a descriptor table every time it accesses
 memory.
 <P>
 Every segment register has a "visible" portion and an "invisible" portion,
-as 
+as
 <A HREF="s05_01.htm#fig5-7">Figure 5-7</A>
   illustrates. The visible portions of these segment address
 registers are manipulated by programs as if they were simply 16-bit
 registers. The invisible portions are manipulated by the processor.
 <P>
 The operations that load these registers are normal program instructions
-(previously described in 
+(previously described in
 <A HREF="c03.htm">Chapter 3</A>). These instructions are of two classes:
 <OL>
-<LI> Direct load instructions; for example, <A HREF="MOV.htm">MOV</A>, 
-<A HREF="POP.htm">POP</A>, 
-<A HREF="LGS.htm">LDS</A>, 
-<A HREF="LGS.htm">LSS</A>, 
-<A HREF="LGS.htm">LGS</A>, 
+<LI> Direct load instructions; for example, <A HREF="MOV.htm">MOV</A>,
+<A HREF="POP.htm">POP</A>,
+<A HREF="LGS.htm">LDS</A>,
+<A HREF="LGS.htm">LSS</A>,
+<A HREF="LGS.htm">LGS</A>,
 <A HREF="LGS.htm">LFS</A>.
 These instructions explicitly reference the segment registers.
 
-<LI> Implied load instructions; for example, far 
+<LI> Implied load instructions; for example, far
 <A HREF="CALL.htm">CALL</A> and <A HREF="JMP.htm">JMP</A>. These
 instructions implicitly reference the CS register, and load it with a
 new value.
@@ -345,7 +345,6 @@ address with no additional overhead.
 <P>
 <B>up:</B> <A HREF="c05.htm">
 Chapter 5 -- Memory Management</A><BR>
-<B>prev:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A><BR> 
+<B>prev:</B> <A HREF="c05.htm">Chapter 5 -- Memory Management</A><BR>
 <B>next:</B> <A HREF="s05_02.htm">5.2  Page Translation</A>
 </BODY>
-

--- a/s05_02.htm
+++ b/s05_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 5.2</TITLE>
 </HEAD>
@@ -29,7 +29,7 @@ Pages begin onbyte boundaries and are fixed in size.
 
 <H2>5.2.2  Linear Address</H2>
 A linear address refers indirectly to a physical address by specifying a
-page table, a page within that table, and an offset within that page. 
+page table, a page within that table, and an offset within that page.
 <A HREF="s05_02.htm#fig5-8">Figure 5-8</A>
   shows the format of a linear address.
 <P>
@@ -100,7 +100,7 @@ The physical address of the current page directory is stored in the CPU
 register CR3, also called the page directory base register (PDBR). Memory
 management software has the option of using one page directory for all
 tasks, one page directory for each task, or some combination of the two.
-Refer to 
+Refer to
 <A HREF="c10.htm">Chapter 10</A>
    for information on initialization of CR3 . Refer to
 
@@ -108,9 +108,9 @@ Refer to
    to see how CR3 can change for each task .
 
 <H2>5.2.4  Page-Table Entries</H2>
-Entries in either level of page tables have the same format. 
+Entries in either level of page tables have the same format.
 <A HREF="s05_02.htm#fig5-10">Figure 5-10</A>
- 
+
 illustrates this format.
 
 <H3>5.2.4.1  Page Frame Address</H3>
@@ -126,9 +126,9 @@ translation. P=1 indicates that the entry can be used.
 <P>
 When P=0 in either level of page tables, the entry is not valid for address
 translation, and the rest of the entry is available for software use; none
-of the other bits in the entry is tested by the hardware. 
+of the other bits in the entry is tested by the hardware.
 <A HREF="s05_02.htm#fig5-11">Figure 5-11</A>
- 
+
 illustrates the format of a page-table entry when P=0.
 <P>
 If P=0 in either level of page tables when an attempt is made to use a
@@ -136,7 +136,7 @@ page-table entry for address translation, the processor signals a page
 exception. In software systems that support paged virtual memory, the
 page-not-present exception handler can bring the required page into physical
 memory. The instruction that caused the exception can then be reexecuted.
-Refer to 
+Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for more information on exception handlers .
 <P>
@@ -144,7 +144,7 @@ Note that there is no present bit for the page directory itself. The page
 directory may be not-present while the associated task is suspended, but the
 operating system must ensure that the page directory indicated by the CR3
 image in the TSS is present in physical memory before the task is
-dispatched . Refer to 
+dispatched . Refer to
 <A HREF="c07.htm">Chapter 7</A>
    for an explanation of the TSS and task
 dispatching.
@@ -201,7 +201,7 @@ to determine what pages to eliminate from physical memory when the demand
 for memory exceeds the physical memory available. The operating system is
 responsible for testing and clearing these bits.
 <P>
-Refer to 
+Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for how the 80386 coordinates updates to the accessed
 and dirty bits in multiprocessor systems.
@@ -209,7 +209,7 @@ and dirty bits in multiprocessor systems.
 <H3>5.2.4.4  Read/Write and User/Supervisor Bits</H3>
 These bits are not used for address translation, but are used for
 page-level protection, which the processor performs at the same time as
-address translation . Refer to 
+address translation . Refer to
 <A HREF="c06.htm">Chapter 6</A>
    where protection is discussed in
 detail.
@@ -225,14 +225,14 @@ programmers but not to systems programmers; operating-system programmers
 must flush the cache whenever the page tables are changed. The
 page-translation cache can be flushed by either of two methods:
 <OL>
-<LI> By reloading CR3 with a <A HREF="MOVRS.htm">MOV</A> instruction; 
+<LI> By reloading CR3 with a <A HREF="MOVRS.htm">MOV</A> instruction;
 for example:
 <PRE>
 <A HREF="MOVRS.htm">MOV</A> CR3, EAX
 </PRE>
 
 <LI> By performing a task switch to a TSS that has a different CR3 image
-than the current TSS . (Refer to 
+than the current TSS . (Refer to
 <A HREF="c07.htm">Chapter 7</A>
    for more information on
 task switching.)

--- a/s05_03.htm
+++ b/s05_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 5.3</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c05.htm">
 Chapter 5 -- Memory Management</A><BR>
 <B>prev:</B> <A HREF="s05_02.htm">5.2  Page Translation</A><BR>
-<B>next:</B> <A HREF="c06.htm">Chapter 6 -- Protection</A><BR> 
+<B>next:</B> <A HREF="c06.htm">Chapter 6 -- Protection</A><BR>
 <P>
 <HR>
 <P>
@@ -92,7 +92,7 @@ subsystem is paging the structure in this manner.
 <H2>5.3.3  Pages Spanning Several Segments</H2>
 On the other hand, segments may be smaller than the size of a page. For
 example, consider a small data structure such as a semaphore. Because of the
-protection and sharing provided by segments (refer to 
+protection and sharing provided by segments (refer to
 <A HREF="c06.htm">Chapter 6</A>
    ) , it may be
 useful to create a separate segment for each semaphore. But, because a
@@ -116,9 +116,9 @@ partially used pages.
 <H2>5.3.6  Page-Table per Segment</H2>
 An approach to space management that provides even further simplification
 of space-management software is to maintain a one-to-one correspondence
-between segment descriptors and page-directory entries, as 
+between segment descriptors and page-directory entries, as
 <A HREF="s05_03.htm#fig5-13">Figure 5-13</A>
- 
+
 illustrates. Each descriptor has a base address in which the low-order 22
 bits are zero; in other words, the base address is mapped by the first entry
 of a page table. A segment may have any limit from 1 to 4 megabytes.

--- a/s06_01.htm
+++ b/s06_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.1</TITLE>
 </HEAD>

--- a/s06_02.htm
+++ b/s06_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.2</TITLE>
 </HEAD>

--- a/s06_03.htm
+++ b/s06_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.3</TITLE>
 </HEAD>
@@ -109,7 +109,7 @@ segments; gate descriptors have a different purpose that is discussed later
 in this chapter.
 <P>
 The type fields of data and executable segment descriptors include bits
-which further define the purpose of the segment (refer to 
+which further define the purpose of the segment (refer to
 <A HREF="s06_03.htm#fig6-1">Figure 6-1</A>
   ):
 <UL>
@@ -234,7 +234,7 @@ B-bit                    X            X            0            1
 
 Lower bound is:          0            0         LIMIT+1  shl(LIMIT,12,1)+1
 
-Upper bound is:        LIMIT  shl(LIMIT,12,1)    64K-1         4G-1 
+Upper bound is:        LIMIT  shl(LIMIT,12,1)    64K-1         4G-1
 
 Max seg size is:        64K           4G         64K-1        4G-4K
                       0-FFFF      0-FFFFFFFF     !(0-0)      !(0-FFF)
@@ -317,7 +317,7 @@ data segment into a data-segment register (DS, ES, FS, GS, SS). The
 processor automatically evaluates access to a data segment by comparing
 privilege levels. The evaluation is performed at the time a selector for the
 descriptor of the target segment is loaded into the data-segment register.
-As 
+As
 <A HREF="s06_03.htm#fig6-3">Figure 6-3</A>
   shows, three different privilege levels enter into this type
 of privilege check:
@@ -395,39 +395,39 @@ valid because the DPL of the code segment in CS is, by definition, equal to
 CPL.
 
 <H2>6.3.3  Restricting Control Transfers</H2>
-With the 80386, control transfers are accomplished by the instructions 
+With the 80386, control transfers are accomplished by the instructions
 <A HREF="JMP.htm">JMP</A>,
-<A HREF="CALL.htm">CALL</A>, 
-<A HREF="RET.htm">RET</A>, 
-<A HREF="INT.htm">INT</A>, and <A HREF="IRET.htm">IRET</A>, 
+<A HREF="CALL.htm">CALL</A>,
+<A HREF="RET.htm">RET</A>,
+<A HREF="INT.htm">INT</A>, and <A HREF="IRET.htm">IRET</A>,
 as well as by the exception and interrupt
-mechanisms . Exceptions and interrupts are special cases that 
+mechanisms . Exceptions and interrupts are special cases that
 <A HREF="c09.htm">Chapter 9</A>
-covers. This chapter discusses only <A HREF="JMP.htm">JMP</A>, 
+covers. This chapter discusses only <A HREF="JMP.htm">JMP</A>,
 <A HREF="CALL.htm">CALL</A>, and <A HREF="RET.htm">RET</A> instructions.
 <P>
-The "near" forms of <A HREF="JMP.htm">JMP</A>, <A HREF="CALL.htm">CALL</A>, and 
+The "near" forms of <A HREF="JMP.htm">JMP</A>, <A HREF="CALL.htm">CALL</A>, and
 <A HREF="RET.htm">RET</A> transfer within the current code
 segment, and therefore are subject only to limit checking. The processor
-ensures that the destination of the <A HREF="JMP.htm">JMP</A>, 
-<A HREF="CALL.htm">CALL</A>, or 
+ensures that the destination of the <A HREF="JMP.htm">JMP</A>,
+<A HREF="CALL.htm">CALL</A>, or
 <A HREF="RET.htm">RET</A> instruction does not
 exceed the limit of the current executable segment. This limit is cached in
 the CS register; therefore, protection checks for near transfers require no
 extra clock cycles.
 <P>
-The operands of the "far" forms of 
-<A HREF="JMP.htm">JMP</A> and 
+The operands of the "far" forms of
+<A HREF="JMP.htm">JMP</A> and
 <A HREF="CALL.htm">CALL</A> refer to other segments;
 therefore, the processor performs privilege checking. There are two ways a
-<A HREF="JMP.htm">JMP</A> or 
+<A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> can refer to another segment:
 <OL>
 <LI> The operand selects the descriptor of another executable segment.
 <LI> The operand selects a call gate descriptor. This gated form of
 transfer is discussed in a later section on call gates.
 </OL>
-As 
+As
 <A HREF="s06_03.htm#fig6-4">Figure 6-4</A>
   shows, two different privilege levels enter into a privilege
 check for a control transfer that does not use a call gate:
@@ -442,8 +442,8 @@ bit is set in the descriptor of the current executable segment. The
 processor keeps a record of the CPL cached in the CS register; this value
 can be different from the DPL in the descriptor of the code segment.
 <P>
-The processor permits a 
-<A HREF="JMP.htm">JMP</A> or 
+The processor permits a
+<A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> directly to another segment only if one
 of the following privilege rules is satisfied:
 <UL>
@@ -464,9 +464,9 @@ Most code segments are not conforming. The basic rules of privilege above
 mean that, for nonconforming segments, control can be transferred without a
 gate only to executable segments at the same level of privilege. There is a
 need, however, to transfer control to (numerically) smaller privilege
-levels; this need is met by the 
+levels; this need is met by the
 <A HREF="CALL.htm">CALL</A> instruction when used with call-gate
-descriptors, which are explained in the next section. The 
+descriptors, which are explained in the next section. The
 <A HREF="JMP.htm">JMP</A> instruction
 may never transfer control to a nonconforming segment whose DPL does not
 equal CPL.
@@ -514,11 +514,11 @@ four kinds of gate descriptors:
 <LI> Task gates
 </UL>
 This chapter is concerned only with call gates. Task gates are used for
-task switching , and therefore are discussed in 
-<A HREF="c07.htm">Chapter 7</A>. 
+task switching , and therefore are discussed in
+<A HREF="c07.htm">Chapter 7</A>.
 <A HREF="c09.htm">Chapter 9</A>
 explains how trap gates and interrupt gates are used by exceptions and
-interrupts. 
+interrupts.
 <A HREF="s06_03.htm#fig6-5">Figure 6-5</A>
   illustrates the format of a call gate. A call gate
 descriptor may reside in the GDT or in an LDT, but not in the IDT.
@@ -538,12 +538,12 @@ segment go to a valid entry point, rather than possibly into the middle of a
 procedure (or worse, into the middle of an instruction). The far pointer
 operand of the control transfer instruction does not point to the segment
 and offset of the target instruction; rather, the selector part of the
-pointer selects a gate, and the offset is not used. 
+pointer selects a gate, and the offset is not used.
 <A HREF="s06_03.htm#fig6-6">Figure 6-6</A>
   illustrates
 this style of addressing.
 <P>
-As 
+As
 <A HREF="s06_03.htm#fig6-7">Figure 6-7</A>
   shows, four different privilege levels are used to check the
 validity of a control transfer via a call gate:
@@ -562,15 +562,15 @@ others may be intended only for use by other systems software.
 <P>
 Gates can be used for control transfers to numerically smaller privilege
 levels or to the same privilege level (though they are not necessary for
-transfers to the same level). Only 
+transfers to the same level). Only
 <A HREF="CALL.htm">CALL</A> instructions can use gates to
-transfer to smaller privilege levels. A gate may be used by a 
+transfer to smaller privilege levels. A gate may be used by a
 <A HREF="JMP.htm">JMP</A>
 instruction only to transfer to an executable segment with the same
 privilege level or to a conforming segment.
 <P>
-For a 
-<A HREF="JMP.htm">JMP</A> instruction to a nonconforming segment, 
+For a
+<A HREF="JMP.htm">JMP</A> instruction to a nonconforming segment,
 both of the following
 privilege rules must be satisfied; otherwise, a general protection exception
 results.
@@ -578,7 +578,7 @@ results.
 MAX (CPL,RPL) <= gate DPL
 target segment DPL = CPL
 </PRE>
-For a <A HREF="CALL.htm">CALL</A> instruction (or for a 
+For a <A HREF="CALL.htm">CALL</A> instruction (or for a
 <A HREF="JMP.htm">JMP</A> instruction to a conforming segment),
 both of the following privilege rules must be satisfied; otherwise, a
 general protection exception results.
@@ -698,8 +698,8 @@ privileged levels. Without them, a trusted procedure would not work
 correctly if the calling procedure did not provide sufficient space on the
 caller's stack.
 <P>
-The processor locates these stacks via the task state segment (see 
-<A HREF="s06_03.htm#fig6-8">Figure 6-8</A>). 
+The processor locates these stacks via the task state segment (see
+<A HREF="s06_03.htm#fig6-8">Figure 6-8</A>).
 Each task has a separate TSS, thereby permitting tasks to have
 separate stacks. Systems software is responsible for creating TSSs and
 placing correct stack pointers in them. The initial stack pointers in the
@@ -734,7 +734,7 @@ an error code of 0.
 <LI> The old value of the stack registers SS:ESP is pushed onto the new
 stack as two doublewords.
 <LI> The parameters are copied.
-<LI> A pointer to the instruction after the 
+<LI> A pointer to the instruction after the
 <A HREF="CALL.htm">CALL</A> instruction (the former
 value of CS:EIP) is pushed onto the new stack. The final value of
 SS:ESP points to this return pointer on the new stack.
@@ -754,10 +754,10 @@ to access all parameters beyond the last doubleword copied.
 <P>
 A call via a call gate does not check the values of the words copied onto
 the new stack. The called procedure should check each parameter for
-validity. A later section discusses how the <A HREF="ARPL.htm">ARPL</A>, 
-<A HREF="VERR.htm">VERR</A>, 
-<A HREF="VERR.htm">VERW</A>, 
-<A HREF="LSL.htm">LSL</A>, and 
+validity. A later section discusses how the <A HREF="ARPL.htm">ARPL</A>,
+<A HREF="VERR.htm">VERR</A>,
+<A HREF="VERR.htm">VERW</A>,
+<A HREF="LSL.htm">LSL</A>, and
 <A HREF="LAR.htm">LAR</A>
 instructions can be used to check pointer values.
 <P>
@@ -823,21 +823,21 @@ instructions can be used to check pointer values.
 </PRE>
 <P>
 <H3>6.3.4.2  Returning from a Procedure</H3>
-The "near" forms of the 
+The "near" forms of the
 <A HREF="RET.htm">RET</A> instruction transfer control within the current
 code segment and therefore are subject only to limit checking. The offset of
-the instruction following the corresponding 
+the instruction following the corresponding
 <A HREF="CALL.htm">CALL</A>, is popped from the stack.
 The processor ensures that this offset does not exceed the limit of the
 current executable segment.
 <P>
-The "far" form of the 
+The "far" form of the
 <A HREF="RET.htm">RET</A> instruction pops the return pointer that was
-pushed onto the stack by a prior far 
+pushed onto the stack by a prior far
 <A HREF="CALL.htm">CALL</A> instruction. Under normal
 conditions, the return pointer is valid, because of its relation to the
-prior <A HREF="CALL.htm">CALL</A> or 
-<A HREF="INT.htm">INT</A>. 
+prior <A HREF="CALL.htm">CALL</A> or
+<A HREF="INT.htm">INT</A>.
 Nevertheless, the processor performs privilege checking
 because of the possibility that the current procedure altered the pointer or
 failed to properly maintain the stack. The RPL of the CS selector popped
@@ -845,7 +845,7 @@ off the stack by the return instruction identifies the privilege level of
 the calling procedure.
 <P>
 An intersegment return instruction can change privilege levels, but only
-toward procedures of lesser privilege. When the 
+toward procedures of lesser privilege. When the
 <A HREF="RET.htm">RET</A> instruction encounters a
 saved CS value whose RPL is numerically greater than the CPL, an interlevel
 return occurs. Such a return follows these steps:
@@ -853,7 +853,7 @@ return occurs. Such a return follows these steps:
 <LI> The checks shown in Table 6-3 are made, and CS:EIP and SS:ESP are
 loaded with their former values that were saved on the stack.
 <LI> The old SS:ESP (from the top of the current stack) value is adjusted
-by the number of bytes indicated in the 
+by the number of bytes indicated in the
 <A HREF="RET.htm">RET</A> instruction. The resulting
 ESP value is not compared to the limit of the stack segment. If ESP is
 beyond the limit, that fact is not recognized until the next stack
@@ -863,7 +863,7 @@ TSS.)
 <LI> The contents of the DS, ES, FS, and GS segment registers are checked.
 If any of these registers refer to segments whose DPL is greater than
 the new CPL (excluding conforming code segments), the segment register
-is loaded with the null selector (INDEX = 0, TI = 0). The 
+is loaded with the null selector (INDEX = 0, TI = 0). The
 <A HREF="RET.htm">RET</A>
 instruction itself does not signal exceptions in these cases;
 however, any subsequent memory reference that attempts to use a
@@ -953,37 +953,37 @@ segment.
 </OL>
 Although the 80386 processor automatically performs checks 2 and 3 during
 instruction execution, software must assist in performing the first check.
-The unprivileged instruction 
+The unprivileged instruction
 <A HREF="ARPL.htm">ARPL</A> is provided for this purpose. Software can
 also explicitly perform steps 2 and 3 to check for potential violations
-(rather than waiting for an exception). The unprivileged instructions 
+(rather than waiting for an exception). The unprivileged instructions
 <A HREF="LAR.htm">LAR</A>,
-<A HREF="LSL.htm">LSL</A>, 
-<A HREF="VERR.htm">VERR</A>, and 
+<A HREF="LSL.htm">LSL</A>,
+<A HREF="VERR.htm">VERR</A>, and
 <A HREF="VERR.htm">VERW</A> are provided for this purpose.
 <P>
 <A HREF="LAR.htm">LAR</A> (Load Access Rights) is used to verify that a pointer refers to a
-segment of the proper privilege level and type. 
+segment of the proper privilege level and type.
 <A HREF="LAR.htm">LAR</A> has one operand
 selector for a descriptor whose access rights are to be examined. The
 descriptor must be visible at the privilege level which is the maximum of
-the CPL and the selector's RPL. If the descriptor is visible, 
+the CPL and the selector's RPL. If the descriptor is visible,
 <A HREF="LAR.htm">LAR</A> obtains a
 masked form of the second doubleword of the descriptor, masks this value
 with 00FxFF00H, stores the result into the specified 32-bit destination
 register, and sets the zero flag. (The x indicates that the corresponding
 four bits of the stored value are undefined.) Once loaded, the access-rights
-bits can be tested. All valid descriptor types can be tested by the 
+bits can be tested. All valid descriptor types can be tested by the
 <A HREF="LAR.htm">LAR</A>
 instruction. If the RPL or CPL is greater than DPL, or if the selector is
 outside the table limit, no access-rights value is returned, and the zero
 flag is cleared. Conforming code segments may be accessed from any privilege
 level.
 <P>
-<A HREF="LSL.htm">LSL</A> 
+<A HREF="LSL.htm">LSL</A>
 (Load Segment Limit) allows software to test the limit of a descriptor.
 If the descriptor denoted by the given selector (in memory or a register) is
-visible at the CPL, 
+visible at the CPL,
 <A HREF="LSL.htm">LSL</A> loads the specified 32-bit register with a 32-bit,
 byte granular, unscrambled limit that is calculated from fragmented limit
 fields and the G-bit of that descriptor. This can only be done for segments
@@ -991,8 +991,8 @@ fields and the G-bit of that descriptor. This can only be done for segments
 inaccessible. (Table 6-4 lists in detail which types are valid and which
 are not.) Interpreting the limit is a function of the segment type. For
 example, downward expandable data segments treat the limit differently than
-code segments do. For both 
-<A HREF="LAR.htm">LAR</A> and 
+code segments do. For both
+<A HREF="LAR.htm">LAR</A> and
 <A HREF="LSL.htm">LSL</A>, the zero flag (ZF) is set if the
 loading was performed; otherwise, the ZF is cleared.
 <PRE>
@@ -1020,16 +1020,16 @@ F      386 Interrupt Gate          NO
 
 </PRE>
 <H3>6.3.6.1  Descriptor Validation</H3>
-The 80386 has two instructions, 
-<A HREF="VERR.htm">VERR</A> and 
+The 80386 has two instructions,
+<A HREF="VERR.htm">VERR</A> and
 <A HREF="VERR.htm">VERW</A>, which determine whether a
 selector points to a segment that can be read or written at the current
 privilege level. Neither instruction causes a protection fault if the result
 is negative.
 <P>
-<A HREF="VERR.htm">VERR</A> (Verify for Reading) 
+<A HREF="VERR.htm">VERR</A> (Verify for Reading)
 verifies a segment for reading and loads ZF with
-1 if that segment is readable from the current privilege level. 
+1 if that segment is readable from the current privilege level.
 <A HREF="VERR.htm">VERR</A> checks
 that:
 <UL>
@@ -1042,10 +1042,10 @@ The privilege check for data segments and nonconforming code segments is
 that the DPL must be numerically greater than or equal to both the CPL and
 the selector's RPL. Conforming segments are not checked for privilege level.
 <P>
-<A HREF="VERR.htm">VERW</A> (Verify for Writing) 
+<A HREF="VERR.htm">VERW</A> (Verify for Writing)
 provides the same capability as <A HREF="VERR.htm">VERR</A> for
-verifying writability. Like the 
-<A HREF="VERR.htm">VERR</A> instruction, 
+verifying writability. Like the
+<A HREF="VERR.htm">VERR</A> instruction,
 <A HREF="VERR.htm">VERW</A> loads ZF if the
 result of the writability check is positive. The instruction checks that the
 descriptor is within bounds, is a segment descriptor, is writable, and that
@@ -1083,7 +1083,7 @@ directly, i.e., the RPL is numerically greater than the DPL, then a
 protection fault will result when that selector is loaded into a segment
 register.
 <P>
-<A HREF="ARPL.htm">ARPL</A> 
+<A HREF="ARPL.htm">ARPL</A>
 (Adjust Requestor's Privilege Level) adjusts the RPL field of a
 selector to become the larger of its original value and the value of the RPL
 field in a specified register. The latter is normally loaded from the image

--- a/s06_04.htm
+++ b/s06_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.4</TITLE>
 </HEAD>
@@ -78,7 +78,7 @@ Certain accesses are checked as if they are privilege-level 0 references,
 even if CPL = 3:
 <UL>
 <LI> LDT, GDT, TSS, IDT references.
-<LI> Access to inner stack during ring-crossing 
+<LI> Access to inner stack during ring-crossing
 <A HREF="CALL.htm">CALL</A>/<A HREF="INT.htm">INT</A>.
 </UL>
 <P>

--- a/s06_05.htm
+++ b/s06_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.5</TITLE>
 </HEAD>

--- a/s07_01.htm
+++ b/s07_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.1</TITLE>
 </HEAD>
@@ -13,11 +13,11 @@ Chapter 7 -- Multitasking</A><BR>
 <P>
 <H1>7.1  Task State Segment</H1>
 All the information the processor needs in order to manage a task is stored
-in a special type of segment, a task state segment (TSS). 
+in a special type of segment, a task state segment (TSS).
 <A HREF="s07_01.htm#fig7-1">Figure 7-1</A>
   shows
 the format of a TSS for executing 80386 tasks. (Another format is used for
-executing 80286 tasks; refer to 
+executing 80286 tasks; refer to
 <A HREF="c13.htm">Chapter 13</A>.)
 <P>
 The fields of a TSS belong to two classes:
@@ -40,11 +40,11 @@ includes the fields that store:
 page directory (read only when paging is enabled).
 <LI> Pointers to the stacks for privilege levels 0-2.
 <LI> The T-bit (debug trap bit) which causes the processor to raise a
-debug exception when a task switch occurs . (Refer to 
+debug exception when a task switch occurs . (Refer to
 <A HREF="c12.htm">Chapter 12</A>
-  
+
 for more information on debugging.)
-<LI> The I/O map base (refer to 
+<LI> The I/O map base (refer to
 <A HREF="c08.htm">Chapter 8</A> for more information on the
 use of the I/O map).
 </UL>

--- a/s07_02.htm
+++ b/s07_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.2</TITLE>
 </HEAD>
@@ -13,7 +13,7 @@ Chapter 7 -- Multitasking</A><BR>
 <P>
 <H1>7.2  TSS Descriptor</H1>
 The task state segment, like all other segments, is defined by a
-descriptor. 
+descriptor.
 <A HREF="s07_02.htm#fig7-2">Figure 7-2</A>
   shows the format of a TSS descriptor.
 <P>

--- a/s07_03.htm
+++ b/s07_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.3</TITLE>
 </HEAD>
@@ -13,7 +13,7 @@ Chapter 7 -- Multitasking</A><BR>
 <P>
 <H1>7.3  Task Register</H1>
 The task register (TR) identifies the currently executing task by pointing
-to the TSS. 
+to the TSS.
 <A HREF="s07_03.htm#fig7-3">Figure 7-3</A>
   shows the path by which the processor accesses the
 current TSS.
@@ -28,26 +28,26 @@ register makes execution of the task more efficient, because the processor
 does not need to repeatedly fetch these values from memory when it
 references the TSS of the current task.
 <P>
-The instructions <A HREF="LTR.htm">LTR</A> and 
+The instructions <A HREF="LTR.htm">LTR</A> and
 <A HREF="STR.htm">STR</A> are used to modify and read the visible
 portion of the task register. Both instructions take one operand, a 16-bit
 selector located in memory or in a general register.
 <P>
-<A HREF="LTR.htm">LTR</A> (Load task register) 
+<A HREF="LTR.htm">LTR</A> (Load task register)
 loads the visible portion of the task register
 with the selector operand, which must select a TSS descriptor in the GDT.
-<A HREF="LTR.htm">LTR</A> 
+<A HREF="LTR.htm">LTR</A>
 also loads the invisible portion with information from the TSS
-descriptor selected by the operand. 
+descriptor selected by the operand.
 <A HREF="LTR.htm">LTR</A> is a privileged instruction; it may
-be executed only when CPL is zero. 
+be executed only when CPL is zero.
 <A HREF="LTR.htm">LTR</A> is generally used during system
 initialization to give an initial value to the task register; thereafter,
 the contents of TR are changed by task switch operations.
 <P>
-<A HREF="STR.htm">STR</A> (Store task register) 
+<A HREF="STR.htm">STR</A> (Store task register)
 stores the visible portion of the task register
-in a general register or memory word. 
+in a general register or memory word.
 <A HREF="STR.htm">STR</A> is not privileged.
 <P>
 <A NAME="fig7-3">

--- a/s07_04.htm
+++ b/s07_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.4</TITLE>
 </HEAD>

--- a/s07_05.htm
+++ b/s07_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.5</TITLE>
 </HEAD>
@@ -14,32 +14,32 @@ Chapter 7 -- Multitasking</A><BR>
 <H1>7.5  Task Switching</H1>
 The 80386 switches execution to another task in any of four cases:
 <OL>
-<LI> The current task executes a <A HREF="JMP.htm">JMP</A> or 
+<LI> The current task executes a <A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> that refers to a TSS
 descriptor.
-<LI> The current task executes a <A HREF="JMP.htm">JMP</A> or 
+<LI> The current task executes a <A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> that refers to a task gate.
 <LI> An interrupt or exception vectors to a task gate in the IDT.
-<LI> The current task executes an 
+<LI> The current task executes an
 <A HREF="IRET.htm">IRET</A> when the NT flag is set.
 </OL>
-<A HREF="JMP.htm">JMP</A>, 
-<A HREF="CALL.htm">CALL</A>, 
-<A HREF="IRET.htm">IRET</A>, 
+<A HREF="JMP.htm">JMP</A>,
+<A HREF="CALL.htm">CALL</A>,
+<A HREF="IRET.htm">IRET</A>,
 interrupts, and exceptions are all ordinary mechanisms of
 the 80386 that can be used in circumstances that do not require a task
 switch. Either the type of descriptor referenced or the NT (nested task) bit
 in the flag word distinguishes between the standard mechanism and the
 variant that causes a task switch.
 <P>
-To cause a task switch, a <A HREF="JMP.htm">JMP</A> or 
+To cause a task switch, a <A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> instruction can refer either to a TSS
 descriptor or to a task gate. The effect is the same in either case: the
 80386 switches to the indicated task.
 <P>
 An exception or interrupt causes a task switch when it vectors to a task
 gate in the IDT. If it vectors to an interrupt or trap gate in the IDT, a
-task switch does not occur . Refer to 
+task switch does not occur . Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for more information on the
 interrupt mechanism.
@@ -47,18 +47,18 @@ interrupt mechanism.
 Whether invoked as a task or as a procedure of the interrupted task, an
 interrupt handler always returns control to the interrupted procedure in the
 interrupted task. If the NT flag is set, however, the handler is an
-interrupt task, and the 
+interrupt task, and the
 <A HREF="IRET.htm">IRET</A> switches back to the interrupted task.
 <P>
 A task switching operation involves these steps:
 <OL>
 <LI> Checking that the current task is allowed to switch to the designated
-task. Data-access privilege rules apply in the case of 
+task. Data-access privilege rules apply in the case of
 <A HREF="JMP.htm">JMP</A> or <A HREF="CALL.htm">CALL</A>
-instructions. The DPL of the TSS descriptor or task gate must be 
+instructions. The DPL of the TSS descriptor or task gate must be
 numerically greater (e.g., lower privilege level)
 than or equal to the maximum of CPL and the RPL of the gate selector.
-Exceptions, interrupts, and 
+Exceptions, interrupts, and
 <A HREF="IRET.htm">IRET</A> are permitted to switch tasks
 regardless of the DPL of the target task gate or TSS descriptor.
 <LI> Checking that the TSS descriptor of the new task is marked present
@@ -114,9 +114,9 @@ from the TSS.
 <PRE>
 Table 7-1. Checks Made during a Task Switch
 
-NP = Segment-not-present exception 
-GP = General protection fault 
-TS = Invalid TSS 
+NP = Segment-not-present exception
+GP = General protection fault
+TS = Invalid TSS
 SF = Stack fault
 
 Validity tests of a selector check that the selector is in the proper
@@ -126,9 +126,9 @@ selector refers to an LDT descriptor).
 
 Test     Test Description                   Exception    Error Code Selects
 
-  1      Incoming TSS descriptor is 
+  1      Incoming TSS descriptor is
          present                            NP           Incoming TSS
-  2      Incoming TSS descriptor is 
+  2      Incoming TSS descriptor is
          marked not-busy                    GP           Incoming TSS
          marked not-busy
   3      Limit of incoming TSS is
@@ -136,25 +136,25 @@ Test     Test Description                   Exception    Error Code Selects
 
              -- All register and selector values are loaded --
 
-  4      LDT selector of incoming 
+  4      LDT selector of incoming
          task is valid                      TS           Incoming TSS
-  5      LDT of incoming task is  
+  5      LDT of incoming task is
          present                            TS           Incoming TSS
   6      CS selector is valid               TS           Code segment
   7      Code segment is present            NP           Code segment
-  8      Code segment DPL matches  
+  8      Code segment DPL matches
          CS RPL                             TS           Code segment
-  9      Stack segment is valid             GP           Stack segment 
+  9      Stack segment is valid             GP           Stack segment
  10      Stack segment is present           SF           Stack segment
  11      Stack segment DPL = CPL            SF           Stack segment
  12      Stack-selector RPL = CPL           GP           Stack segment
  13      DS, ES, FS, GS selectors are
          valid                              GP           Segment
- 14      DS, ES, FS, GS segments 
+ 14      DS, ES, FS, GS segments
          are readable                       GP           Segment
- 15      DS, ES, FS, GS segments 
+ 15      DS, ES, FS, GS segments
          are present                        NP           Segment
- 16      DS, ES, FS, GS segment DPL  
+ 16      DS, ES, FS, GS segment DPL
          >= CPL (unless these are
          conforming segments)               GP           Segment
 </PRE>

--- a/s07_06.htm
+++ b/s07_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.6</TITLE>
 </HEAD>
@@ -13,16 +13,16 @@ Chapter 7 -- Multitasking</A><BR>
 <P>
 <H1>7.6  Task Linking</H1>
 The back-link field of the TSS and the NT (nested task) bit of the flag
-word together allow the 80386 to automatically return to a task that 
+word together allow the 80386 to automatically return to a task that
 <A HREF="CALL.htm">CALL</A>ed
-another task or was interrupted by another task. When a 
+another task or was interrupted by another task. When a
 <A HREF="CALL.htm">CALL</A> instruction, an
 interrupt instruction, an external interrupt, or an exception causes a
 switch to a new task, the 80386 automatically fills the back-link of the new
 TSS with the selector of the outgoing task's TSS and, at the same time,
 sets the NT bit in the new task's flag register. The NT flag indicates
 whether the back-link field is valid. The new task releases control by
-executing an <A HREF="IRET.htm">IRET</A> instruction. When interpreting an 
+executing an <A HREF="IRET.htm">IRET</A> instruction. When interpreting an
 <A HREF="IRET.htm">IRET</A>, the 80386 examines
 the NT flag. If NT is set, the 80386 switches back to the task selected by
 the back-link field. Table 7-2 summarizes the uses of these fields.
@@ -66,10 +66,10 @@ The processor uses the busy bit as follows:
 bit of the new task.
 <LI> When switching from a task, the processor automatically clears the
 busy bit of the old task if that task is not to be placed on the
-back-link chain (i.e., the instruction causing the task switch is 
+back-link chain (i.e., the instruction causing the task switch is
 <A HREF="JMP.htm">JMP</A>
-or 
-<A HREF="IRET.htm">IRET</A>). 
+or
+<A HREF="IRET.htm">IRET</A>).
 If the task is placed on the back-link chain, its busy bit
 remains set.
 <LI> When switching to a task, the processor signals an exception if the
@@ -82,7 +82,7 @@ into a task.
 The busy bit is effective even in multiprocessor configurations, because
 the processor automatically asserts a bus lock when it sets or clears the
 busy bit. This action ensures that two processors do not invoke the same
-task at the same time . (Refer to 
+task at the same time . (Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for more on multiprocessing.)
 

--- a/s07_07.htm
+++ b/s07_07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 7.7</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c07.htm">
 Chapter 7 -- Multitasking</A><BR>
 <B>prev:</B> <A HREF="s07_06.htm">7.6  Task Linking</A><BR>
-<B>next:</B> <A HREF="c08.htm">Chapter 8 -- Input/Output</A><BR> 
+<B>next:</B> <A HREF="c08.htm">Chapter 8 -- Input/Output</A><BR>
 <P>
 <HR>
 <P>
@@ -58,7 +58,7 @@ map to the same physical addresses. The task state segments must lie in a
 common space so that the mapping of TSS addresses does not change while the
 processor is reading and updating the TSSs during a task switch. The linear
 space mapped by the GDT should also be mapped to a common physical space;
-otherwise, the purpose of the GDT is defeated. 
+otherwise, the purpose of the GDT is defeated.
 <A HREF="s07_07.htm#fig7-6">Figure 7-6</A>
   shows how the
 linear spaces of two tasks can overlap in the physical space by sharing

--- a/s08_01.htm
+++ b/s08_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 8.1</TITLE>
 </HEAD>
@@ -49,9 +49,9 @@ a single bus access. Like words in memory, 16-bit ports should be aligned at
 even-numbered addresses so that the 16 bits can be transferred in a single
 bus access. An 8-bit port may be located at either an even or odd address.
 <P>
-The instructions <A HREF="IN.htm">IN</A> and 
+The instructions <A HREF="IN.htm">IN</A> and
 <A HREF="OUT.htm">OUT</A> move data between a register and a port in the
-I/O address space. The instructions <A HREF="INS.htm">INS</A> and 
+I/O address space. The instructions <A HREF="INS.htm">INS</A> and
 <A HREF="OUTS.htm">OUTS</A> move strings of data
 between the memory address space and ports in the I/O address space.
 
@@ -64,7 +64,7 @@ Memory-mapped I/O provides additional programming flexibility. Any
 instruction that references memory may be used to access an I/O port located
 in the memory space. For example, the <A HREF="MOV.htm">MOV</A> instruction can transfer data
 between any register and a port; and the <A HREF="AND.htm">AND</A>, <A HREF="OR.htm">OR</A>, and <A HREF="TEST.htm">TEST</A> instructions may
-be used to manipulate bits in the internal registers of a device (see 
+be used to manipulate bits in the internal registers of a device (see
 <A HREF="s08_02.htm#fig8-1">Figure 8-1</A>
   ). Memory-mapped I/O performed via the full instruction set maintains
 the full complement of addressing modes for selecting the desired I/O
@@ -72,9 +72,9 @@ device (e.g., direct address, indirect address, base register, index
 register, scaling).
 <P>
 Memory-mapped I/O, like any other memory reference, is subject to access
-protection and control when executing in protected mode. Refer to 
+protection and control when executing in protected mode. Refer to
 <A HREF="c06.htm">Chapter 6</A>
-  
+
 for a discussion of memory protection.
 <P>
 <HR>

--- a/s08_02.htm
+++ b/s08_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 8.2</TITLE>
 </HEAD>
@@ -25,30 +25,30 @@ instructions" or "block I/O instructions".
 </OL>
 
 <H2>8.2.1  Register I/O Instructions</H2>
-The I/O instructions <A HREF="IN.htm">IN</A> and 
+The I/O instructions <A HREF="IN.htm">IN</A> and
 <A HREF="OUT.htm">OUT</A>are provided to move data between I/O ports
 and the EAX (32-bit I/O), the AX (16-bit I/O), or AL (8-bit I/O) general
-registers. <A HREF="IN.htm">IN</A> and 
+registers. <A HREF="IN.htm">IN</A> and
 <A HREF="OUT.htm">OUT</A>instructions address I/O ports either directly, with
 the address of one of up to 256 port addresses coded in the instruction, or
 indirectly via the DX register to one of up to 64K port addresses.
 <P>
-<A HREF="IN.htm">IN</A> (Input from Port) 
+<A HREF="IN.htm">IN</A> (Input from Port)
 transfers a byte, word, or doubleword from an input
-port to AL, AX, or EAX. If a program specifies AL with the 
+port to AL, AX, or EAX. If a program specifies AL with the
 <A HREF="IN.htm">IN</A> instruction,
 the processor transfers 8 bits from the selected port to AL. If a program
-specifies AX with the 
+specifies AX with the
 <A HREF="IN.htm">IN</A> instruction, the processor transfers 16 bits from
-the port to AX. If a program specifies EAX with the 
+the port to AX. If a program specifies EAX with the
 <A HREF="IN.htm">IN</A> instruction, the
 processor transfers 32 bits from the port to EAX.
 <P>
-<A HREF="OUT.htm">OUT</A>(Output to Port) 
+<A HREF="OUT.htm">OUT</A>(Output to Port)
 transfers a byte, word, or doubleword to an output
 port from AL, AX, or EAX. The program can specify the number of the port
 using the same methods as the <A HREF="IN.htm">IN</A> instruction.
-<P>   
+<P>
 <A NAME="fig8-1">
 <PRE>Figure 8-1.  Memory-Mapped I/O</PRE>
 <P>
@@ -75,11 +75,11 @@ using the same methods as the <A HREF="IN.htm">IN</A> instruction.
 </PRE>
 
 <H2>8.2.2  Block I/O Instructions</H2>
-The block (or string) I/O instructions 
-<A HREF="INS.htm">INS</A> and 
+The block (or string) I/O instructions
+<A HREF="INS.htm">INS</A> and
 <A HREF="OUTS.htm">OUTS</A> move blocks of data
 between I/O ports and memory space. Block I/O instructions use the DX
-register to specify the address of a port in the I/O address space. 
+register to specify the address of a port in the I/O address space.
 <A HREF="INS.htm">INS</A> and
 <A HREF="OUTS.htm">OUTS</A>use DX to specify:
 <UL>
@@ -92,17 +92,17 @@ destination memory address. For each transfer, SI or DI are automatically
 either incremented or decremented as specified by the direction bit in the
 flags register.
 <P>
-<A HREF="INS.htm">INS</A> and <A HREF="OUTS.htm">OUTS</A>, 
+<A HREF="INS.htm">INS</A> and <A HREF="OUTS.htm">OUTS</A>,
 when used with repeat prefixes, cause block input or output
-operations. 
-<A HREF="REP.htm">REP</A>, the repeat prefix, modifies 
+operations.
+<A HREF="REP.htm">REP</A>, the repeat prefix, modifies
 <A HREF="INS.htm">INS</A> and <A HREF="OUTS.htm">OUTS</A> to provide a means
 of transferring blocks of data between an I/O port and memory. These block
-I/O instructions are string primitives (refer also to 
+I/O instructions are string primitives (refer also to
 <A HREF="c03.htm">Chapter 3</A>
    for more on
 string primitives). They simplify programming and increase the speed of data
-transfer by eliminating the need to use a separate 
+transfer by eliminating the need to use a separate
 <A HREF="LOOP.htm">LOOP</A> instruction or an
 intermediate register to hold the data.
 <P>
@@ -113,45 +113,45 @@ doubleword operands. The value in the direction flag (DF) determines whether
 the processor automatically increments ESI or EDI (DF=0) or whether it
 automatically decrements these registers (DF=1).
 <P>
-<A HREF="INS.htm">INS</A>(Input String from Port) 
+<A HREF="INS.htm">INS</A>(Input String from Port)
 transfers a byte or a word string element from
-an input port to memory. The mnemonics 
-<A HREF="INS.htm">INSB</A>, 
-<A HREF="INS.htm">INSW</A>, and 
+an input port to memory. The mnemonics
+<A HREF="INS.htm">INSB</A>,
+<A HREF="INS.htm">INSW</A>, and
 <A HREF="INS.htm">INSD</A> are variants
 that explicitly specify the size of the operand. If a program specifies
-<A HREF="INS.htm">INSB</A>, 
+<A HREF="INS.htm">INSB</A>,
 the processor transfers 8 bits from the selected port to the memory
-location indicated by ES:EDI. If a program specifies 
+location indicated by ES:EDI. If a program specifies
 <A HREF="INS.htm">INSW</A>, the processor
 transfers 16 bits from the port to the memory location indicated by ES:EDI.
-If a program specifies 
+If a program specifies
 <A HREF="INS.htm">INSD</A>, the processor transfers 32 bits from the port
 to the memory location indicated by ES:EDI. The destination segment register
-choice (ES) cannot be changed for the 
+choice (ES) cannot be changed for the
 <A HREF="INS.htm">INS</A> instruction. Combined with the
-<A HREF="REP.htm">REP</A> prefix, 
-<A HREF="INS.htm">INS</A> moves a block of information from an input 
+<A HREF="REP.htm">REP</A> prefix,
+<A HREF="INS.htm">INS</A> moves a block of information from an input
 port to a series of consecutive memory locations.
 <P>
-<A HREF="OUTS.htm">OUTS</A> (Output String to Port) 
+<A HREF="OUTS.htm">OUTS</A> (Output String to Port)
 transfers a byte, word, or doubleword string
-element to an output port from memory. The mnemonics 
-<A HREF="OUTS.htm">OUTSB</A>, 
-<A HREF="OUTS.htm">OUTSW</A>, and 
+element to an output port from memory. The mnemonics
+<A HREF="OUTS.htm">OUTSB</A>,
+<A HREF="OUTS.htm">OUTSW</A>, and
 <A HREF="OUTS.htm">OUTSD</A>
 are variants that explicitly specify the size of the operand. If a program
-specifies 
-<A HREF="OUTS.htm">OUTSB</A>, the processor transfers 8 bits 
+specifies
+<A HREF="OUTS.htm">OUTSB</A>, the processor transfers 8 bits
 from the memory location
-indicated by ES:EDI to the the selected port. If a program specifies 
+indicated by ES:EDI to the the selected port. If a program specifies
 <A HREF="OUTS.htm">OUTSW</A>,
 the processor transfers 16 bits from the memory location indicated by ES:EDI
-to the the selected port. If a program specifies 
+to the the selected port. If a program specifies
 <A HREF="OUTS.htm">OUTSD</A>, the processor
 transfers 32 bits from the memory location indicated by ES:EDI to the the
-selected port. Combined with the 
-<A HREF="REP.htm">REP</A> prefix, 
+selected port. Combined with the
+<A HREF="REP.htm">REP</A> prefix,
 <A HREF="OUTS.htm">OUTS</A> moves a block of
 information from a series of consecutive memory locations indicated by
 DS:ESI to an output port.

--- a/s08_03.htm
+++ b/s08_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 8.3</TITLE>
 </HEAD>
@@ -55,18 +55,18 @@ permitting all procedures of the task to perform I/O. Other tasks typically
 have IOPL set to zero or one, reserving the right to perform I/O
 instructions for the most privileged procedures.
 <P>
-A task can change IOPL only with the 
+A task can change IOPL only with the
 <A HREF="POPF.htm">POPF</A> instruction; however, such
 changes are privileged. No procedure may alter IOPL (the I/O privilege level
 in the flag register) unless the procedure is executing at privilege level
 0. An attempt by a less privileged procedure to alter IOPL does not result
 in an exception; IOPL simply remains unaltered.
 <P>
-The <A HREF="POPF.htm">POPF</A> instruction may be used in addition to 
+The <A HREF="POPF.htm">POPF</A> instruction may be used in addition to
 <A HREF="CLI.htm">CLI</A> and <A HREF="STI.htm">STI</A> to alter the
-interrupt-enable flag (IF); however, changes to IF by 
+interrupt-enable flag (IF); however, changes to IF by
 <A HREF="POPF.htm">POPF</A> are
-IOPL-sensitive. A procedure may alter IF with a 
+IOPL-sensitive. A procedure may alter IF with a
 <A HREF="POPF.htm">POPF</A> instruction only when
 executing at a level that is at least as privileged as IOPL. An attempt by a
 less privileged procedure to alter IF in this manner does not result in an
@@ -74,14 +74,14 @@ exception; IF simply remains unaltered.
 
 <H2>8.3.2  I/O Permission Bit Map</H2>
 The I/O instructions that directly refer to addresses in the processor's
-I/O space are 
-<A HREF="IN.htm">IN</A>, 
-<A HREF="INS.htm">INS</A>, 
-<A HREF="OUT.htm">OUT</A>, 
+I/O space are
+<A HREF="IN.htm">IN</A>,
+<A HREF="INS.htm">INS</A>,
+<A HREF="OUT.htm">OUT</A>,
 <A HREF="OUTS.htm">OUTS</A>. The 80386 has the ability to selectively
 trap references to specific I/O addresses. The structure that enables
 selective trapping is the I/O Permission Bit Map in the TSS segment (see
-<A HREF="s08_03.htm#fig8-2">Figure 8-2</A>). 
+<A HREF="s08_03.htm#fig8-2">Figure 8-2</A>).
 The I/O permission map is a bit vector. The size of the map
 and its location in the TSS segment are variable. The processor locates the
 I/O permission map by means of the I/O map base field in the fixed portion
@@ -89,15 +89,15 @@ of the TSS. The I/O map base field is 16 bits wide and contains the offset
 of the beginning of the I/O permission map. The upper limit of the I/O
 permission map is the same as the limit of the TSS segment.
 <P>
-In protected mode, when it encounters an I/O instruction 
-(<A HREF="IN.htm">IN</A>, 
-<A HREF="INS.htm">INS</A>, 
+In protected mode, when it encounters an I/O instruction
+(<A HREF="IN.htm">IN</A>,
+<A HREF="INS.htm">INS</A>,
 <A HREF="OUT.htm">OUT</A>, or
-<A HREF="OUTS.htm">OUTS</A>), the processor first checks whether CPL <= IOPL. 
+<A HREF="OUTS.htm">OUTS</A>), the processor first checks whether CPL <= IOPL.
 If this condition is
 true, the I/O operation may proceed. If not true, the processor checks the
 I/O permission map. (In virtual 8086 mode, the processor consults the map
-without regard for IOPL . Refer to 
+without regard for IOPL . Refer to
 <A HREF="c15.htm">Chapter 15</A>.)
 <P>
 Each bit in the map corresponds to an I/O port byte address; for example,

--- a/s09_01.htm
+++ b/s09_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c09.htm">
 Chapter 9 -- Exceptions and Interrupts</A><BR>
-<B>prev:</B> <A HREF="c09.htm">Chapter 9 -- Exceptions and Interrupts</A><BR> 
+<B>prev:</B> <A HREF="c09.htm">Chapter 9 -- Exceptions and Interrupts</A><BR>
 <B>next:</B> <A HREF="s09_02.htm">9.2  Enabling and Disabling Interrupts</A>
 <P>
 <HR>
@@ -32,7 +32,7 @@ they are reported and whether restart of the instruction that caused the
 exception is supported.
 <DL>
 <DT>
-Faults  
+Faults
 <DD>
 Faults are exceptions that are reported "before" the
 instruction causingthe exception. Faults are either detected before
@@ -41,13 +41,13 @@ instruction. If detected during the instruction, the fault is
 reported with the machine restored to a state that permits the
 instruction to be restarted.
 <DT>
-Traps   
+Traps
 <DD>
 A trap is an exception that is reported at the instruction
 boundary immediately after the instruction in which the
 exception was detected.
 <DT>
-Aborts  
+Aborts
 <DD>
 An abort is an exception that permits neither precise location
 of the instruction causing the exception nor restart of the program

--- a/s09_02.htm
+++ b/s09_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.2</TITLE>
 </HEAD>
@@ -30,10 +30,10 @@ The IF (interrupt-enable flag) controls the acceptance of external
 interrupts signalled via the INTR pin. When IF=0, INTR interrupts are
 inhibited; when IF=1, INTR interrupts are enabled. As with the other flag
 bits, the processor clears IF in response to a RESET signal. The
-instructions <A HREF="CLI.htm">CLI</A> and 
+instructions <A HREF="CLI.htm">CLI</A> and
 <A HREF="STI.htm">STI</A> alter the setting of IF.
 <P>
-<A HREF="CLI.htm">CLI</A> (Clear Interrupt-Enable Flag) and 
+<A HREF="CLI.htm">CLI</A> (Clear Interrupt-Enable Flag) and
 <A HREF="STI.htm">STI</A> (Set Interrupt-Enable Flag)
 explicitly alter IF (bit 9 in the flag register). These instructions may be
 executed only if CPL <= IOPL. A protection exception occurs if they are
@@ -41,11 +41,11 @@ executed when CPL > IOPL.
 <P>
 The IF is also affected implicitly by the following operations:
 <UL>
-<LI> The instruction 
+<LI> The instruction
 <A HREF="PUSHF.htm">PUSHF</A> stores all flags, including IF, in the stack
 where they can be examined.
-<LI> Task switches and the instructions 
-<A HREF="POPF.htm">POPF</A> and 
+<LI> Task switches and the instructions
+<A HREF="POPF.htm">POPF</A> and
 <A HREF="IRET.htm">IRET</A> load the flags
 register; therefore, they can be used to modify IF.
 <LI> Interrupts through interrupt gates automatically reset IF, disabling
@@ -55,7 +55,7 @@ interrupts. (Interrupt gates are explained later in this chapter.)
 <H2>9.2.3  RF Masks Debug Faults</H2>
 The RF bit in EFLAGS controls the recognition of debug faults. This permits
 debug faults to be raised for a given instruction at most once, no matter
-how many times the instruction is restarted . (Refer to 
+how many times the instruction is restarted . (Refer to
 <A HREF="c12.htm">Chapter 12</A>
    for more
 information on debugging.)
@@ -72,13 +72,13 @@ before ESP has received the corresponding change, the two parts of the stack
 pointer SS:ESP are inconsistent for the duration of the interrupt handler or
 exception handler.
 <P>
-To prevent this situation, the 80386, after both a 
-<A HREF="MOV.htm">MOV</A> to SS and a 
+To prevent this situation, the 80386, after both a
+<A HREF="MOV.htm">MOV</A> to SS and a
 <A HREF="POP.htm">POP</A> to
 SS instruction, inhibits NMI, INTR, debug exceptions, and single-step traps
 at the instruction boundary following the instruction that changes SS. Some
 exceptions may still occur; namely, page fault and general protection fault.
-Always use the 80386 
+Always use the 80386
 <A HREF="LGS.htm">LSS</A> instruction, and the problem will not occur.
 <P>
 <HR>

--- a/s09_03.htm
+++ b/s09_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.3</TITLE>
 </HEAD>
@@ -14,7 +14,7 @@ Chapter 9 -- Exceptions and Interrupts</A><BR>
 <H1>9.3  Priority Among Simultaneous Interrupts and Exceptions</H1>
 If more than one interrupt or exception is pending at an instruction
 boundary, the processor services one of them at a time. The priority among
-classes of interrupt and exception sources is shown in 
+classes of interrupt and exception sources is shown in
 <A HREF="s09_04.htm#Table 9-2">Table 9-2</A>. The
 processor first services a pending interrupt or exception from the class
 that has the highest priority, transferring control to the first

--- a/s09_04.htm
+++ b/s09_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.4</TITLE>
 </HEAD>
@@ -22,26 +22,26 @@ identifiers, the IDT need not contain more than 256 descriptors. It can
 contain fewer than 256 entries; entries are required only for interrupt
 identifiers that are actually used.
 <P>
-The IDT may reside anywhere in physical memory. As 
+The IDT may reside anywhere in physical memory. As
 <A HREF="s09_04.htm#fig9-1">Figure 9-1</A>
   shows, the
 processor locates the IDT by means of the IDT register (IDTR). The
-instructions 
-<A HREF="LGDT.htm">LIDT</A> and 
+instructions
+<A HREF="LGDT.htm">LIDT</A> and
 <A HREF="SGDT.htm">SIDT</A> operate on the IDTR. Both instructions have one
-explicit operand: the address in memory of a 6-byte area. 
+explicit operand: the address in memory of a 6-byte area.
 <A HREF="s09_04.htm#fig9-2">Figure 9-2</A>
   shows
 the format of this area.
 <P>
-<A HREF="LGDT.htm">LIDT</A> (Load IDT register) 
+<A HREF="LGDT.htm">LIDT</A> (Load IDT register)
 loads the IDT register with the linear base
 address and limit values contained in the memory operand.  This instruction
 can be executed only when the CPL is zero. It is normally used by the
 initialization logic of an operating system when creating an IDT.  An
 operating system may also use it to change from one IDT to another.
 <P>
-<A HREF="SGDT.htm">SIDT</A> (Store IDT register) 
+<A HREF="SGDT.htm">SIDT</A> (Store IDT register)
 copies the base and limit value stored in IDTR
 to a memory location. This instruction can be executed at any privilege
 level.

--- a/s09_05.htm
+++ b/s09_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.5</TITLE>
 </HEAD>
@@ -22,7 +22,7 @@ The IDT may contain any of three kinds of descriptor:
 <A HREF="s09_05.htm#fig9-3">Figure 9-3</A>
   illustrates the format of task gates and 80386 interrupt gates
 and trap gates. (The task gate in an IDT is the same as the task gate
-already discussed in 
+already discussed in
 <A HREF="c07.htm">Chapter 7</A>.)
 <P>
 <A NAME="fig9-3">

--- a/s09_06.htm
+++ b/s09_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.6</TITLE>
 </HEAD>
@@ -32,7 +32,7 @@ gate points to the beginning of the interrupt or exception handling
 procedure.
 <P>
 The 80386 invokes an interrupt or exception handling procedure in much the
-same manner as it 
+same manner as it
 <A HREF="CALL.htm">CALL</A>s a procedure; the differences are explained in the
 following sections.
 <P>
@@ -80,10 +80,10 @@ exception.
 
 <H3>9.6.1.2  Returning from an Interrupt Procedure</H3>
 An interrupt procedure also differs from a normal procedure in the method
-of leaving the procedure. The 
+of leaving the procedure. The
 <A HREF="IRET.htm">IRET</A> instruction is used to exit from an
-interrupt procedure. <A HREF="IRET.htm">IRET</A> is similar to 
-<A HREF="RET.htm">RET</A> except that 
+interrupt procedure. <A HREF="IRET.htm">IRET</A> is similar to
+<A HREF="RET.htm">RET</A> except that
 <A HREF="IRET.htm">IRET</A> increments ESP
 by an extra four bytes (because of the flags on the stack) and moves the
 saved flags into the EFLAGS register. The IOPL field of EFLAGS is changed
@@ -146,7 +146,7 @@ The difference between an interrupt gate and a trap gate is in the effect
 on IF (the interrupt-enable flag). An interrupt that vectors through an
 interrupt gate resets IF, thereby preventing other interrupts from
 interfering with the current interrupt handler. A subsequent
-<A HREF="IRET.htm">IRET</A> 
+<A HREF="IRET.htm">IRET</A>
 instruction restores IF to the value in the EFLAGS image on the stack. An
 interrupt through a trap gate does not change IF.
 
@@ -172,7 +172,7 @@ privilege level three, thereby making it unprotected.
 </UL>
 <P>
 <H2>9.6.2  Interrupt Tasks</H2>
-A task gate in the IDT points indirectly to a task, as 
+A task gate in the IDT points indirectly to a task, as
 <A HREF="s09_06.htm#fig9-6">Figure 9-6</A>
 illustrates. The selector of the gate points to a TSS descriptor in the GDT.
 <P>
@@ -185,8 +185,8 @@ advantages:
 separate address space, either via its LDT or via its page directory.
 </UL>
 The actions that the processor takes to perform a task switch are discussed
-in 
-<A HREF="c07.htm">Chapter 7</A>. 
+in
+<A HREF="c07.htm">Chapter 7</A>.
 The interrupt task returns to the interrupted task by
 executing an <A HREF="IRET.htm">IRET</A> instruction.
 <P>

--- a/s09_07.htm
+++ b/s09_07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.7</TITLE>
 </HEAD>
@@ -14,7 +14,7 @@ Chapter 9 -- Exceptions and Interrupts</A><BR>
 <H1>9.7  Error Code</H1>
 With exceptions that relate to a specific segment, the processor pushes an
 error code onto the stack of the exception handler (whether procedure or
-task). The error code has the format shown in 
+task). The error code has the format shown in
 <A HREF="s09_07.htm#fig9-7">Figure 9-7</A>
   . The format of the
 error code resembles that of a selector; however, instead of an RPL field,

--- a/s09_08.htm
+++ b/s09_08.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.8</TITLE>
 </HEAD>
@@ -18,24 +18,24 @@ abort. This classification provides information needed by systems
 programmers for restarting the procedure in which the exception occurred:
 <DL>
 <DT>
-Faults   
+Faults
 <DD>
 The CS and EIP values saved when a fault is reported point to the
 instruction causing the fault.
 <DT>
-Traps    
+Traps
 <DD>
 The CS and EIP values stored when the trap is reported point to the
 instruction dynamically after the instruction causing the trap. If
 a trap is detected during an instruction that alters program flow,
 the reported values of CS and EIP reflect the alteration of program
-flow. For example, if a trap is detected in a 
+flow. For example, if a trap is detected in a
 <A HREF="JMP.htm">JMP</A> instruction, the
 CS and EIP values pushed onto the stack point to the target of the
-<A HREF="JMP.htm">JMP</A>, not to the instruction after the 
+<A HREF="JMP.htm">JMP</A>, not to the instruction after the
 <A HREF="JMP.htm">JMP</A>.
 <DT>
-Aborts   
+Aborts
 <DD>
 An abort is an exception that permits neither precise location of
 the instruction causing the exception nor restart of the program
@@ -45,7 +45,7 @@ system tables.
 </DL>
 
 <H2>9.8.1 Interrupt 0 -- Divide Error</H2>
-The divide-error fault occurs during a <A HREF="DIV.htm">DIV</A> or an 
+The divide-error fault occurs during a <A HREF="DIV.htm">DIV</A> or an
 <A HREF="IDIV.htm">IDIV</A> instruction when the
 divisor is zero.
 
@@ -61,17 +61,17 @@ whether the exception is a fault or a trap depends on the condition:
 </UL>
 The processor does not push an error code for this exception. An exception
 handler can examine the debug registers to determine which condition caused
-the exception . Refer to 
+the exception . Refer to
 <A HREF="c12.htm">Chapter 12</A>
    for more detailed information about
 debugging and the debug registers.
 
 <H2>9.8.3 Interrupt 3 -- Breakpoint</H2>
-The <A HREF="INT.htm">INT</A> 3 instruction causes this trap. The 
+The <A HREF="INT.htm">INT</A> 3 instruction causes this trap. The
 <A HREF="INT.htm">INT</A> 3 instruction is one byte
 long, which makes it easy to replace an opcode in an executable segment with
 the breakpoint opcode. The operating system or a debugging subsystem can use
-a data-segment alias for an executable segment to place an 
+a data-segment alias for an executable segment to place an
 <A HREF="INT.htm">INT</A> 3 anywhere it
 is convenient to arrest normal execution so that some sort of special
 processing can be performed. Debuggers typically use breakpoints as a way of
@@ -79,13 +79,13 @@ displaying registers, variables, etc., at crucial points in a task.
 <P>
 The saved CS:EIP value points to the byte following the breakpoint. If a
 debugger replaces a planted breakpoint with a valid opcode, it must subtract
-one from the saved EIP value before returning . Refer also to 
+one from the saved EIP value before returning . Refer also to
 <A HREF="c12.htm">Chapter 12</A>
    for
 more information on debugging.
 
 <H2>9.8.4 Interrupt 4 -- Overflow</H2>
-This trap occurs when the processor encounters an 
+This trap occurs when the processor encounters an
 <A HREF="INT.htm">INTO</A> instruction and the
 OF (overflow) flag is set. Since signed arithmetic and unsigned arithmetic
 both use the same arithmetic instructions, the processor cannot determine
@@ -96,7 +96,7 @@ operands, careful programmers and compilers either test OF directly or use
 the <A HREF="INT.htm">INTO</A> instruction.
 
 <H2>9.8.5 Interrupt 5 -- Bounds Check</H2>
-This fault occurs when the processor, while executing a 
+This fault occurs when the processor, while executing a
 <A HREF="BOUND.htm">BOUND</A> instruction,
 finds that the operand exceeds the specified limits. A program can use the
 <A HREF="BOUND.htm">BOUND</A>
@@ -111,9 +111,9 @@ exception.) No error code is pushed on the stack. The exception can be
 handled within the same task.
 <P>
 This exception also occurs when the type of operand is invalid for the
-given opcode. Examples include an intersegment 
+given opcode. Examples include an intersegment
 <A HREF="JMP.htm">JMP</A> referencing a register
-operand, or an 
+operand, or an
 <A HREF="LGS.htm">LES</A> instruction with a register source operand.
 
 <H2>9.8.7 Interrupt 7 -- Coprocessor Not Available</H2>
@@ -121,12 +121,12 @@ This exception occurs in either of two conditions:
 <UL>
 <LI> The processor encounters an ESC (escape) instruction, and the EM
 (emulate) bit ofCR0 (control register zero) is set.
-<LI> The processor encounters either the 
+<LI> The processor encounters either the
 <A HREF="WAIT.htm">WAIT</A> instruction or an ESC
 instruction, and both the MP (monitor coprocessor) and TS (task
 switched) bits of CR0 are set.
 </UL>
-Refer to 
+Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for information about the coprocessor interface .
 
@@ -136,10 +136,10 @@ the handler for a prior exception, the two exceptions can be handled
 serially. If, however, the processor cannot handle them serially, it signals
 the double-fault exception instead. To determine when two faults are to be
 signalled as a double fault, the 80386 divides the exceptions into three
-classes: benign exceptions, contributory exceptions, and page faults. 
+classes: benign exceptions, contributory exceptions, and page faults.
 <A HREF="s09_08.htm#Table 9-3">Table 9-3</A> shows this classification.
 <P>
-<A HREF="s09_08.htm#Table 9-4">Table 9-4</A> 
+<A HREF="s09_08.htm#Table 9-4">Table 9-4</A>
 shows which combinations of exceptions cause a double fault and
 which do not.
 <P>
@@ -198,14 +198,14 @@ EXCEPTION  Exception
 <H2>9.8.9 Interrupt 9 -- Coprocessor Segment Overrun</H2>
 This exception is raised in protected mode if the 80386 detects a page or
 segment violation while transferring the middle portion of a coprocessor
-operand to the NPX . This exception is avoidable. Refer to 
+operand to the NPX . This exception is avoidable. Refer to
 <A HREF="c11.htm">Chapter 11</A>
    for
 more information about the coprocessor interface.
 
 <H2>9.8.10 Interrupt 10 -- Invalid TSS</H2>
 Interrupt 10 occurs if during a task switch the new TSS is invalid. A TSS
-is considered invalid in the cases shown in 
+is considered invalid in the cases shown in
 <A HREF="s09_08.htm#Table 9-5">Table 9-5</A>. An error code is
 pushed onto the stack to help identify the cause of the fault. The EXT bit
 indicates whether the exception was caused by a condition outside the
@@ -217,7 +217,7 @@ context of the new task. Until the processor has completely verified the
 presence of the new TSS, the exception occurs in the context of the original
 task. Once the existence of the new TSS is verified, the task switch is
 considered complete; i.e., TR is updated and, if the switch is due to a
-<A HREF="CALL.htm">CALL</A> 
+<A HREF="CALL.htm">CALL</A>
 or interrupt, the backlink of the new TSS is set to the old TSS. Any
 errors discovered by the processor after this point are handled in the
 context of the new task.
@@ -254,7 +254,7 @@ cases:
 <UL>
 <LI> While attempting to load the CS, DS, ES, FS, or GS registers; loading
 the SS register, however, causes a stack fault.
-<LI> While attempting loading the LDT register with an 
+<LI> While attempting loading the LDT register with an
 <A HREF="LLDT.htm">LLDT</A> instruction;
 loading the LDT register during a task switch operation, however,
 causes the "invalid TSS" exception.
@@ -279,9 +279,9 @@ handle this case:
 interrupted task will cause the processor to check the registers as it
 loads them from the TSS.
 
-<LI> 
-<A HREF="PUSH.htm">PUSH</A> and 
-<A HREF="POP.htm">POP</A> all segment registers. Each 
+<LI>
+<A HREF="PUSH.htm">PUSH</A> and
+<A HREF="POP.htm">POP</A> all segment registers. Each
 <A HREF="POP.htm">POP</A> causes the processor to
 check the new contents of the segment register.
 
@@ -292,7 +292,7 @@ register.
 This exception pushes an error code onto the stack. The EXT bit of the
 error code is set if an event external to the program caused an interrupt
 that subsequently referenced a not-present segment. The I-bit is set if the
-error code refers to an IDT entry, e.g., an 
+error code refers to an IDT entry, e.g., an
 <A HREF="INT.htm">INT</A> instruction referencing a
 not-present gate.
 <P>
@@ -307,25 +307,25 @@ of special significance to the operating system.
 A stack fault occurs in either of two general conditions:
 <UL>
 <LI> As a result of a limit violation in any operation that refers to the
-SS register. This includes stack-oriented instructions such as 
+SS register. This includes stack-oriented instructions such as
 <A HREF="POP.htm">POP</A>,
-<A HREF="PUSH.htm">PUSH</A>, 
-<A HREF="ENTER.htm">ENTER</A>, and 
+<A HREF="PUSH.htm">PUSH</A>,
+<A HREF="ENTER.htm">ENTER</A>, and
 <A HREF="LEAVE.htm">LEAVE</A>, as well as other memory references that
-implicitly use SS (for example, <TT><A HREF="MOV.htm">MOV</A> AX, [BP+6]</TT>). 
+implicitly use SS (for example, <TT><A HREF="MOV.htm">MOV</A> AX, [BP+6]</TT>).
 <A HREF="ENTER.htm">ENTER</A> causes this
 exception when the stack is too small for the indicated local-variable
 space.
 <LI> When attempting to load the SS register with a descriptor that is
 marked not-present but is otherwise valid. This can occur in a task
-switch, an interlevel 
-<A HREF="CALL.htm">CALL</A>, an interlevel return, an 
+switch, an interlevel
+<A HREF="CALL.htm">CALL</A>, an interlevel return, an
 <A HREF="LGS.htm">LSS</A> instruction,
 or a <A HREF="MOV.htm">MOV</A> or <A HREF="POP.htm">POP</A> instruction to SS.
 </UL>
 When the processor detects a stack exception, it pushes an error code onto
 the stack of the exception handler. If the exception is due to a not-present
-stack segment or to overflow of the new stack during an interlevel 
+stack segment or to overflow of the new stack during an interlevel
 <A HREF="CALL.htm">CALL</A>, the
 error code contains a selector to the segment in question (the exception
 handler can test the present bit in the descriptor to determine which
@@ -401,7 +401,7 @@ The processor makes available to the page fault handler two items of
 information that aid in diagnosing the exception and recovering from it:
 <UL>
 <LI> An error code on the stack. The error code for a page fault has a
-format different from that for other exceptions (see 
+format different from that for other exceptions (see
 <A HREF="s09_08.htm#fig9-8">Figure 9-8</A>
   ). The
 error code tells the exception handler three things:
@@ -414,7 +414,7 @@ the time of the exception.
 write.
 </OL>
 <LI> CR2 (control register two). The processor stores in CR2 the linear
-address used in the access that caused the exception (see 
+address used in the access that caused the exception (see
 <A HREF="s09_08.htm#fig9-9">Figure 9-9</A>).
 The exception handler can use this address to locate the corresponding
 page directory and page table entries. If another page fault can occur
@@ -507,7 +507,7 @@ pointer.
 In systems that implement paging and that handle page faults within the
 faulting task (with trap or interrupt gates), software that executes at the
 same privilege level as the page fault handler should initialize a new stack
-by using the new 
+by using the new
 <A HREF="LGS.htm">LSS</A> instruction rather than an instruction pair shown
 above. When the page fault handler executes at privilege level zero (the
 normal case), the scope of the problem is limited to privilege-level zero
@@ -516,7 +516,7 @@ code, typically the kernel of the operating system.
 <H2>9.8.15 Interrupt 16 -- Coprocessor Error</H2>
 The 80386 reports this exception when it detects a signal from the 80287 or
 80387 on the 80386's ERROR# input pin. The 80386 tests this pin only at the
-beginning of certain ESC instructions and when it encounters a 
+beginning of certain ESC instructions and when it encounters a
 <A HREF="WAIT.htm">WAIT</A>
 instruction while the EM bit of the MSW is zero (no emulation). Refer to
 <A HREF="c11.htm">Chapter 11</A>

--- a/s09_09.htm
+++ b/s09_09.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.9</TITLE>
 </HEAD>

--- a/s09_10.htm
+++ b/s09_10.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 9.10</TITLE>
 </HEAD>

--- a/s10_01.htm
+++ b/s10_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c10.htm">
 Chapter 10 -- Initialization</A><BR>
-<B>prev:</B> <A HREF="c10.htm">Chapter 10 -- Initialization</A><BR> 
+<B>prev:</B> <A HREF="c10.htm">Chapter 10 -- Initialization</A><BR>
 <B>next:</B> <A HREF="s10_02.htm">10.2  Software Initialization for Real-Address Mode</A>
 <P>
 <HR>
@@ -19,12 +19,12 @@ value in EAX after self-test indicates that the particular 80386 unit is
 faulty. If the self-test is not requested, the contents of EAX after RESET
 is undefined.
 <P>
-DX holds a component identifier and revision number after RESET as 
+DX holds a component identifier and revision number after RESET as
 <A HREF="s10_01.htm#fig10-1">Figure 10-1</A>
   illustrates. DH contains 3, which indicates an 80386 component. DL
 contains a unique identifier of the revision level.
 <P>
-Control register zero (CR0) contains the values shown in 
+Control register zero (CR0) contains the values shown in
 <A HREF="s10_01.htm#fig10-2">Figure 10-2</A>
   . The
 ET bit of CR0 is set if an 80387 is present in the configuration (according

--- a/s10_02.htm
+++ b/s10_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.2</TITLE>
 </HEAD>
@@ -38,8 +38,8 @@ instruction fetches. This fact, together with the initial values of CS:IP,
 causes instruction execution to begin at physical address FFFFFFF0H. Near
 (intrasegment) forms of control transfer instructions may be used to pass
 control to other addresses in the upper 64K bytes of the address space. The
-first far (intersegment) 
-<A HREF="JMP.htm">JMP</A> or 
+first far (intersegment)
+<A HREF="JMP.htm">JMP</A> or
 <A HREF="CALL.htm">CALL</A> instruction causes A{31-20} to drop
 low, and the 80386 continues executing instructions in the lower one
 megabyte of physical memory. This automatic assertion of address lines

--- a/s10_03.htm
+++ b/s10_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.3</TITLE>
 </HEAD>

--- a/s10_04.htm
+++ b/s10_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.4</TITLE>
 </HEAD>
@@ -51,7 +51,7 @@ enabled:
 <UL>
 <LI> The page that is currently being executed should map to the same
 physical addresses both before and after PG is set.
-<LI> A 
+<LI> A
 <A HREF="JMP.htm">JMP</A> instruction should immediately follow the setting of PG.
 </UL>
 

--- a/s10_05.htm
+++ b/s10_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.5</TITLE>
 </HEAD>

--- a/s10_06.htm
+++ b/s10_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 10.6</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c10.htm">
 Chapter 10 -- Initialization</A><BR>
 <B>prev:</B> <A HREF="s10_05.htm">10.5  Initialization Example</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c11.htm">Chapter 11 -- Coprocessing and Multiprocessing</A>
 <P>
 <HR>
@@ -34,7 +34,7 @@ When testing the TLB it is recommended that paging be turned off (PG=0 in
 CR0) to avoid interference with the test data being written to the TLB.
 
 <H2>10.6.1  Structure of the TLB</H2>
-The TLB is a four-way set-associative memory. 
+The TLB is a four-way set-associative memory.
 <A HREF="s10_06.htm#fig10-3">Figure 10-3</A>
   illustrates the
 structure of the TLB. There are four sets of eight entries each. Each entry
@@ -44,18 +44,18 @@ bits. The data portion of each entry contains the high-order 20 bits of the
 physical address.
 
 <H2>10.6.2  Test Registers</H2>
-Two test registers, shown in 
+Two test registers, shown in
 <A HREF="s10_06.htm#fig10-4">Figure 10-4</A>, are provided for the purpose of
 testing. TR6 is the test command register, and TR7 is the test data
-register. These registers are accessed by variants of the 
+register. These registers are accessed by variants of the
 <A HREF="MOVRS.htm">MOV</A>
 instruction. A test register may be either the source operand or destination
-operand. The 
-<A HREF="MOVRS.htm">MOV</A> instructions are defined in both 
+operand. The
+<A HREF="MOVRS.htm">MOV</A> instructions are defined in both
 real-address mode and
 protected mode. The test registers are privileged resources; in protected
-mode, the 
-<A HREF="MOVRS.htm">MOV</A> instructions that access them can only 
+mode, the
+<A HREF="MOVRS.htm">MOV</A> instructions that access them can only
 be executed at
 privilege level 0. An attempt to read or write the test registers when
 executing at any other privilege level causes a general
@@ -65,7 +65,7 @@ The test command register (TR6) contains a command and an address tag to
 use in performing the command:
 <DL>
 <DT>
-C         
+C
 <DD>
 This is the command bit. There are two TLB testing commands:
 write entries into the TLB, and perform TLB lookups. To cause an
@@ -73,7 +73,7 @@ immediate write into the TLB entry, move a doubleword into TR6
 that contains a 0 in this bit. To cause an immediate TLB lookup,
 move a doubleword into TR6 that contains a 1 in this bit.
 <DT>
-Linear Address   
+Linear Address
 <DD>
 On a TLB write, a TLB entry is allocated to this linear address;
 the rest of that TLB entry is set per the value of TR7 and the
@@ -82,22 +82,22 @@ interrogated per this value; if one and only one TLB entry
 matches, the rest of the fields of TR6 and TR7 are set from the
 matching TLB entry.
 <DT>
-V         
+V
 <DD>
 The valid bit for this TLB entry. The TLB uses the valid bit to
 identify entries that contain valid data. Entries of the TLB
 that have not been assigned values have zero in the valid bit.
 All valid bits can be cleared by writing to CR3.
 <DT>
-D, D#     
+D, D#
 <DD>
 The dirty bit (and its complement) for/from the TLB entry.
 <DT>
-U, U#     
+U, U#
 <DD>
 The U/S bit (and its complement) for/from the TLB entry.
 <DT>
-W, W#     
+W, W#
 <DD>
 The R/W bit (and its complement) for/from the TLB entry.
 <P>
@@ -108,7 +108,7 @@ The test data register (TR7) holds data read from or data to be written to
 the TLB.
 <DL>
 <DT>
-Physical Address 
+Physical Address
 <DD>
 This is the data field of the TLB. On a write to the TLB, the
 TLB entry allocated to the linear address in TR6 is set to this
@@ -116,7 +116,7 @@ value. On a TLB lookup, if HT is set, the data field (physical
 address) from the TLB is read out to this field. If HT is not
 set, this field is undefined.
 <DT>
-HT        
+HT
 <DD>
 For a TLB lookup, the HT bit indicates whether the lookup was a
 hit (HT := 1) or a miss (HT := 0). For a TLB write, HT must be set
@@ -125,7 +125,7 @@ to 1.
 <A HREF="REP.htm">REP</A>
 <DD>
 For a TLB write, selects which of four associative blocks of the
-TLB is to be written. For a TLB read, if HT is set, 
+TLB is to be written. For a TLB read, if HT is set,
 <A HREF="REP.htm">REP</A> reports
 in which of the four associative blocks the tag was found; if HT
 is not set, <A HREF="REP.htm">REP</A> is undefined.
@@ -217,7 +217,7 @@ TLB Lookup           after TLB Write
 To write a TLB entry:
 <OL>
 <LI> Move a doubleword to TR7 that contains the desired physical address,
-HT, and <A HREF="REP.htm">REP</A> values. HT must contain 1. 
+HT, and <A HREF="REP.htm">REP</A> values. HT must contain 1.
 <A HREF="REP.htm">REP</A> must point to the
 associative block in which to place the entry.
 <LI> Move a doubleword to TR6 that contains the appropriate linear

--- a/s11_01.htm
+++ b/s11_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 11.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c11.htm">
 Chapter 11 -- Coprocessing and Multiprocessing</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="c11.htm">Chapter 11 -- Coprocessing and Multiprocessing</A><BR>
 <B>next:</B> <A HREF="s11_02.htm">11.2  General Multiprocessing</A>
 <P>
@@ -46,7 +46,7 @@ since the last ESC instruction.
 <LI> For some ESC instructions, tests the ERROR# pin to determine whether
 the coprocessor detected an error in the previous ESC instruction.
 </UL>
-The <A HREF="WAIT.htm">WAIT</A> instruction is not an ESC instruction, but 
+The <A HREF="WAIT.htm">WAIT</A> instruction is not an ESC instruction, but
 <A HREF="WAIT.htm">WAIT</A> causes the CPU to
 perform some of the same tests that it performs upon encountering an ESC
 instruction. The processor performs the following actions for a <A HREF="WAIT.htm">WAIT</A>

--- a/s11_02.htm
+++ b/s11_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 11.2</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c11.htm">
 Chapter 11 -- Coprocessing and Multiprocessing</A><BR>
 <B>prev:</B> <A HREF="s11_01.htm">11.1  Coprocessing</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c12.htm">Chapter 12 -- Debugging</A>
 <P>
 <HR>
@@ -16,7 +16,7 @@ Chapter 11 -- Coprocessing and Multiprocessing</A><BR>
 The components of the general multiprocessing interface include:
 <UL>
 <LI> The LOCK# signal
-<LI> The 
+<LI> The
 <A HREF="LOCK.htm">LOCK</A> instruction prefix, which gives programmed control of the
 LOCK# signal.
 <LI> Automatic assertion of the LOCK# signal with implicit memory updates
@@ -26,27 +26,27 @@ by the processor
 <H2>11.2.1  LOCK and the LOCK# Signal</H2>
 The <A HREF="LOCK.htm">LOCK</A> instruction prefix and its corresponding output signal LOCK# can
 be used to prevent other bus masters from interrupting a data movement
-operation. 
-<A HREF="LOCK.htm">LOCK</A> may only be used with the following 
+operation.
+<A HREF="LOCK.htm">LOCK</A> may only be used with the following
 80386 instructions when
-they modify memory. An undefined-opcode exception results from using 
+they modify memory. An undefined-opcode exception results from using
 <A HREF="LOCK.htm">LOCK</A>
 before any instruction other than:
 <UL>
-<LI> Bit test and change: <A HREF="BTS.htm">BTS</A>, <A HREF="BTR.htm">BTR</A>, 
+<LI> Bit test and change: <A HREF="BTS.htm">BTS</A>, <A HREF="BTR.htm">BTR</A>,
 <A HREF="BTC.htm">BTC</A>.
 <LI> Exchange: <A HREF="XCHG.htm">XCHG</A>.
-<LI> Two-operand arithmetic and logical: <A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
+<LI> Two-operand arithmetic and logical: <A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
 <A HREF="XOR.htm">XOR</A>.
-<LI> One-operand arithmetic and logical: 
-<A HREF="INC.htm">INC</A>, 
-<A HREF="DEC.htm">DEC</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<LI> One-operand arithmetic and logical:
+<A HREF="INC.htm">INC</A>,
+<A HREF="DEC.htm">DEC</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>.
 </UL>
 A locked instruction is only guaranteed to lock the area of memory defined
@@ -58,8 +58,8 @@ instruction on exactly the same memory area, i.e., an operand with
 identical starting address and identical length.
 <P>
 The integrity of the lock is not affected by the alignment of the memory
-field. The 
-<A HREF="LOCK.htm">LOCK</A> signal is asserted for as many bus 
+field. The
+<A HREF="LOCK.htm">LOCK</A> signal is asserted for as many bus
 cycles as necessary to update the entire operand.
 
 <H2>11.2.2  Automatic Locking</H2>
@@ -97,9 +97,9 @@ The processor exerts LOCK# while updating the A (accessed) and D
 (dirty) bits of page-table entries.  Also the processor bypasses the
 page-table cache and directly updates these bits in memory.
 <LI> Executing <A HREF="XCHG.htm">XCHG</A> instruction.
-The 80386 always asserts <A HREF="LOCK.htm">LOCK</A> during an 
+The 80386 always asserts <A HREF="LOCK.htm">LOCK</A> during an
 <A HREF="XCHG.htm">XCHG</A>instruction that
-references memory (even if the 
+references memory (even if the
 <A HREF="LOCK.htm">LOCK</A> prefix is not used).
 </UL>
 
@@ -141,6 +141,6 @@ affected by this convention.
 <B>up:</B> <A HREF="c11.htm">
 Chapter 11 -- Coprocessing and Multiprocessing</A><BR>
 <B>prev:</B> <A HREF="s11_01.htm">11.1  Coprocessing</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c12.htm">Chapter 12 -- Debugging</A>
 </BODY>

--- a/s12_01.htm
+++ b/s12_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 12.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c12.htm">
 Chapter 12 -- Debugging</A><BR>
-<B>prev:</B> <A HREF="c12.htm">Chapter 12 -- Debugging</A><BR> 
+<B>prev:</B> <A HREF="c12.htm">Chapter 12 -- Debugging</A><BR>
 <B>next:</B> <A HREF="s12_02.htm">12.2  Debug Registers</A>
 <P>
 <HR>
@@ -75,6 +75,6 @@ debugger can be invoked under any of the following kinds of conditions:
 <P>
 <B>up:</B> <A HREF="c12.htm">
 Chapter 12 -- Debugging</A><BR>
-<B>prev:</B> <A HREF="c12.htm">Chapter 12 -- Debugging</A><BR> 
+<B>prev:</B> <A HREF="c12.htm">Chapter 12 -- Debugging</A><BR>
 <B>next:</B> <A HREF="s12_02.htm">12.2  Debug Registers</A>
 </BODY>

--- a/s12_02.htm
+++ b/s12_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 12.2</TITLE>
 </HEAD>
@@ -18,7 +18,7 @@ the source operand or destination operand. The debug registers are
 privileged resources; the <A HREF="MOVRS.htm">MOV</A> instructions that access them can only be
 executed at privilege level zero. An attempt to read or write the debug
 registers when executing at any other privilege level causes a general
-protection exception. 
+protection exception.
 <A HREF="s12_02.htm#fig12-1">Figure 12-1</A>
   shows the format of the debug registers.
 <P>
@@ -75,7 +75,7 @@ bits in DR7.
 The debug address registers are effective whether or not paging is enabled.
 The addresses in these registers are linear addresses. If paging is enabled,
 the linear addresses are translated into physical addresses by the
-processor's paging mechanism (as explained in 
+processor's paging mechanism (as explained in
 <A HREF="c05.htm">Chapter 5</A>
    ) . If paging is not
 enabled, these linear addresses are the same as physical addresses.
@@ -88,7 +88,7 @@ bits indicate whether a given debug address has a global (all tasks) or
 local (current task only) relevance.
 
 <H2>12.2.2  Debug Control Register (DR7)</H2>
-The debug control register shown in 
+The debug control register shown in
 <A HREF="s12_02.htm#fig12-1">Figure 12-1</A>
   both helps to define the
 debug conditions and selectively enables and disables those conditions.
@@ -129,7 +129,7 @@ recommended that one of these bits be set whenever data breakpoints are
 armed. The processor clears LE at a task switch but does not clear GE.
 
 <H2>12.2.3  Debug Status Register (DR6)</H2>
-The debug status register shown in 
+The debug status register shown in
 <A HREF="s12_02.htm#fig12-1">Figure 12-1</A>
   permits the debugger to
 determine which debug conditions have occurred.
@@ -175,7 +175,7 @@ breakpoint addresses will not yield the expected results.
 <P>
 A data read or write breakpoint is triggered if any of the bytes
 participating in a memory access is within the field defined by a breakpoint
-address register and the corresponding LEN field. 
+address register and the corresponding LEN field.
 <A HREF="s12_02.htm#Table 12-1">Table 12-1</A> gives some
 examples of breakpoint fields with memory references that both do and do not
 cause traps.

--- a/s12_03.htm
+++ b/s12_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 12.3</TITLE>
 </HEAD>
@@ -7,7 +7,7 @@
 <B>up:</B> <A HREF="c12.htm">
 Chapter 12 -- Debugging</A><BR>
 <B>prev:</B> <A HREF="s12_02.htm">12.2  Debug Registers</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A>
 <P>
 <HR>
@@ -24,7 +24,7 @@ The handler for this exception is usually a debugger or part of a debugging
 system. The processor causes interrupt 1 for any of several conditions. The
 debugger can check flags in DR6 and DR7 to determine what condition caused
 the exception and what other conditions might be in effect at the same time.
-<A HREF="s12_03.htm#Table 12-2">Table 12-2</A> 
+<A HREF="s12_03.htm#Table 12-2">Table 12-2</A>
 associates with each breakpoint condition the combination of
 bits that indicate when that condition has caused the debug exception.
 <P>
@@ -63,12 +63,12 @@ instruction. (Note, however, that RF does not cause breakpoint traps to be
 ignored, nor other kinds of faults.)
 <P>
 The processor automatically clears RF at the successful completion of every
-instruction except after the 
-<A HREF="IRET.htm">IRET</A> instruction, after the 
+instruction except after the
+<A HREF="IRET.htm">IRET</A> instruction, after the
 <A HREF="POPF.htm">POPF</A> instruction,
-and after a 
-<A HREF="JMP.htm">JMP</A>, 
-<A HREF="CALL.htm">CALL</A>, or 
+and after a
+<A HREF="JMP.htm">JMP</A>,
+<A HREF="CALL.htm">CALL</A>, or
 <A HREF="INT.htm">INT</A> instruction that causes a task switch. These
 instructions set RF to the value specified by the memory image of the EFLAGS
 register.
@@ -76,7 +76,7 @@ register.
 The processor automatically sets RF in the EFLAGS image on the stack before
 entry into any fault handler. Upon entry into the fault handler for
 instruction address breakpoints, for example, RF is set in the EFLAGS image
-on the stack; therefore, the 
+on the stack; therefore, the
 <A HREF="IRET.htm">IRET</A> instruction at the end of the handler will
 set RF in the EFLAGS register, and execution will resume at the breakpoint
 address without generating another breakpoint fault at the same address.
@@ -88,14 +88,14 @@ also be done with RF=1, with the result that debug faults continue to be
 ignored. The processor clears RF only after successful completion of the
 instruction.
 <P>
-Real-mode debuggers can control the RF flag by using a 32-bit 
+Real-mode debuggers can control the RF flag by using a 32-bit
 <A HREF="IRET.htm">IRET</A>. A
-16-bit 
-<A HREF="IRET.htm">IRET</A> instruction does not affect the RF bit 
+16-bit
+<A HREF="IRET.htm">IRET</A> instruction does not affect the RF bit
 (which is in the
 high-order 16 bits of EFLAGS). To use a 32-bit <A HREF="IRET.htm">IRET</A>, the debugger must
 rearrange the stack so that it holds appropriate values for the 32-bit EIP,
-CS, and EFLAGS (with RF set in the EFLAGS image). Then executing an 
+CS, and EFLAGS (with RF set in the EFLAGS image). Then executing an
 <A HREF="IRET.htm">IRET</A>
 with an operand size prefix causes a 32-bit return, popping the RF flag
 into EFLAGS.
@@ -138,7 +138,7 @@ examining the BD bit of DR6.
 This debug condition occurs at the end of an instruction if the trap flag
 (TF) of the flags register held the value one at the beginning of that
 instruction.  Note that the exception does not occur at the end of an
-instruction that sets TF. For example, if 
+instruction that sets TF. For example, if
 <A HREF="POPF.htm">POPF</A> is used to set TF, a
 single-step trap does not occur until after the instruction that follows
 <A HREF="POPF.htm">POPF</A>.
@@ -148,11 +148,11 @@ the flags image of a TSS at the time of a task switch, the exception occurs
 after the first instruction is executed in the new task.
 <P>
 The single-step flag is normally not cleared by privilege changes inside a
-task.  
-<A HREF="INT.htm">INT</A> instructions, however, do clear TF.  
+task.
+<A HREF="INT.htm">INT</A> instructions, however, do clear TF.
 Therefore, software
-debuggers that single-step code must recognize and emulate 
-<A HREF="INT.htm">INT n</A> or 
+debuggers that single-step code must recognize and emulate
+<A HREF="INT.htm">INT n</A> or
 <A HREF="INT.htm">INTO</A>
 rather than executing them directly.
 <P>
@@ -167,7 +167,7 @@ processed first. This clears the TF bit. After saving the return address or
 switching tasks, the external interrupt input is examined before the first
 instruction of the single step handler executes.  If the external interrupt
 is still pending, it is then serviced. The external interrupt handler is not
-single-stepped. To single step an interrupt handler, just single step an 
+single-stepped. To single step an interrupt handler, just single step an
 <A HREF="INT.htm">INT</A>
 n instruction that refers to the interrupt handler.
 
@@ -175,7 +175,7 @@ n instruction that refers to the interrupt handler.
 The debug exception also occurs after a switch to an 80386 task if the
 T-bit of the new TSS is set.  The exception occurs after control has passed
 to the new task, but before the first instruction of that task is executed.
-The exception handler can detect this condition by examining the 
+The exception handler can detect this condition by examining the
 BT bit of
 the debug status register DR6.
 <P>
@@ -184,11 +184,11 @@ should not be set. Failure to observe this rule will cause the processor to
 enter an infinite loop.
 
 <H2>12.3.2 Interrupt 3 -- Breakpoint Exception</H2>
-This exception is caused by execution of the breakpoint instruction 
+This exception is caused by execution of the breakpoint instruction
 <A HREF="INT.htm">INT</A> 3.
 Typically, a debugger prepares a breakpoint by substituting the opcode of
 the one-byte breakpoint instruction in place of the first opcode byte of the
-instruction to be trapped. When execution of the 
+instruction to be trapped. When execution of the
 <A HREF="INT.htm">INT</A> 3 instruction causes
 the exception handler to be invoked, the saved value of ES:EIP points to the
 byte following the <A HREF="INT.htm">INT</A> 3 instruction.
@@ -208,5 +208,5 @@ greater number of breakpoints than permitted by the debug registers.
 Chapter 12 -- Debugging</A><BR>
 <B>prev:</B> <A HREF="s12_02.htm">12.2  Debug Registers</A><BR>
 <B>next:</B>
-<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A> 
+<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A>
 </BODY>

--- a/s13_01.htm
+++ b/s13_01.htm
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 13.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c13.htm">
 Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR>
-<B>prev:</B> 
-<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR> 
+<B>prev:</B>
+<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR>
 <B>next:</B> <A HREF="s13_02.htm">13.2  Two ways to Execute 80286 Tasks</A>
 <P>
 <HR>
@@ -33,27 +33,27 @@ presence of zeros in the final word causes the 80386 to interpret these
 descriptors exactly as 80286 does; for example:
 <DL>
 <DT>
-Base Address      
+Base Address
 <DD>
 The high-order eight bits of the 32-bit base address are
 zero, limiting base addresses to 24 bits.
 <DT>
-Limit             
+Limit
 <DD>
 The high-order four bits of the limit field are zero,
 restricting the value of the limit field to 64K.
 <DT>
-Granularity bit   
+Granularity bit
 <DD>
 The granularity bit is zero, which implies that the value
 of the 16-bit limit is interpreted in units of one byte.
 <DT>
-B-bit             
+B-bit
 <DD>
 In a data-segment descriptor, the B-bit is zero, implying
 that the segment is no larger than 64 Kbytes.
 <DT>
-D-bit             
+D-bit
 <DD>
 In an executable-segment descriptor, the D-bit is zero,
 implying that 16-bit addressing and operands are the
@@ -67,6 +67,6 @@ the iAPX 286 Programmer's Reference Manual.
 <B>up:</B> <A HREF="c13.htm">
 Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR>
 <B>prev:</B>
-<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR> 
+<A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A><BR>
 <B>next:</B> <A HREF="s13_02.htm">13.2  Two ways to Execute 80286 Tasks</A>
 </BODY>

--- a/s13_02.htm
+++ b/s13_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 13.2</TITLE>
 </HEAD>
@@ -29,7 +29,7 @@ changed to 80386 TSSs. It is theoretically possible to mix 80286 and
 is recommended that all tasks in a 80386 software system have 80386
 TSSs. It is not necessary to change the 80286 object modules
 themselves; TSSs are usually constructed by the operating system, by
-the loader , or by the system builder . Refer to 
+the loader , or by the system builder . Refer to
 <A HREF="c16.htm">Chapter 16</A>
    for further
 discussion of the interface between 16-bit and 32-bit code.

--- a/s13_03.htm
+++ b/s13_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 13.3</TITLE>
 </HEAD>

--- a/s14_01.htm
+++ b/s14_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c14.htm">
 Chapter 14 -- 80386 Real-Address Mode</A><BR>
-<B>prev:</B> <A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode</A><BR> 
+<B>prev:</B> <A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode</A><BR>
 <B>next:</B> <A HREF="s14_02.htm">14.2  Registers and Instructions</A>
 <P>
 <HR>
@@ -16,7 +16,7 @@ The 80386 provides a one Mbyte + 64 Kbyte memory space for an 8086 program.
 Segment relocation is performed as in the 8086: the 16-bit value in a
 segment selector is shifted left by four bits to form the base address of a
 segment. The effective address is extended with four high order zeros and
-added to the base to form a linear address as 
+added to the base to form a linear address as
 <A HREF="s14_01.htm#fig14-1">Figure 14-1</A>
   illustrates. (The
 linear address is equivalent to the physical address, because paging is not

--- a/s14_02.htm
+++ b/s14_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.2</TITLE>
 </HEAD>
@@ -22,15 +22,15 @@ operands through the use of the operand size prefix.
 <P>
 The instruction codes that cause undefined opcode traps (interrupt 6)
 include instructions of the protected mode that manipulate or interrogate
-80386 selectors and descriptors; namely, 
-<A HREF="VERR.htm">VERR</A>, 
-<A HREF="VERR.htm">VERW</A>, 
-<A HREF="LAR.htm">LAR</A>, 
-<A HREF="LSL.htm">LSL</A>, 
-<A HREF="LTR.htm">LTR</A>, 
+80386 selectors and descriptors; namely,
+<A HREF="VERR.htm">VERR</A>,
+<A HREF="VERR.htm">VERW</A>,
+<A HREF="LAR.htm">LAR</A>,
+<A HREF="LSL.htm">LSL</A>,
+<A HREF="LTR.htm">LTR</A>,
 <A HREF="STR.htm">STR</A>,
-<A HREF="LLDT.htm">LLDT</A>, and 
-<A HREF="SLDT.htm">SLDT</A>. 
+<A HREF="LLDT.htm">LLDT</A>, and
+<A HREF="SLDT.htm">SLDT</A>.
 Programs executing in real-address mode are able to take
 advantage of the new applications-oriented instructions added to the
 architecture by the introduction of the 80186/80188, 80286 and 80386:
@@ -38,19 +38,19 @@ architecture by the introduction of the 80186/80188, 80286 and 80386:
 <LI> New instructions introduced by 80186/80188 and 80286.
 <UL>
 <LI> <A HREF="PUSH.htm">PUSH</A> immediate data
-<LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and 
+<LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and
 <A HREF="POPA.htm">POPA</A>)
 <LI> Multiply immediate data
 <LI> Shift and rotate by immediate count
 <LI> String I/O
-<LI> <A HREF="ENTER.htm">ENTER</A> and 
+<LI> <A HREF="ENTER.htm">ENTER</A> and
 <A HREF="LEAVE.htm">LEAVE</A>
 <LI> <A HREF="BOUND.htm">BOUND</A>
 </UL>
 <LI> New instructions introduced by 80386.
 <UL>
-<LI> <A HREF="LGS.htm">LSS</A>, 
-<A HREF="LGS.htm">LFS</A>, 
+<LI> <A HREF="LGS.htm">LSS</A>,
+<A HREF="LGS.htm">LFS</A>,
 <A HREF="LGS.htm">LGS</A> instructions
 <LI> Long-displacement conditional jumps
 <LI> Single-bit instructions

--- a/s14_03.htm
+++ b/s14_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.3</TITLE>
 </HEAD>
@@ -28,13 +28,13 @@ The primary difference in the interrupt handling of the 80386 compared to
 the 8086 is that the location and size of the interrupt table depend on the
 contents of the IDTR (IDT register). Ordinarily, this fact is not apparent
 to programmers, because, after RESET, the IDTR contains a base address of 0
-and a limit of 3FFH, which is compatible with the 8086. However, the 
+and a limit of 3FFH, which is compatible with the 8086. However, the
 <A HREF="LGDT.htm">LIDT</A>
 instruction can be used in real-address mode to change the base and limit
-values in the IDTR . Refer to 
+values in the IDTR . Refer to
 <A HREF="c09.htm">Chapter 9</A>
    for details on the IDTR , and the
-<A HREF="LGDT.htm">LIDT</A> and <A HREF="SGDT.htm">SIDT</A> instructions. 
+<A HREF="LGDT.htm">LIDT</A> and <A HREF="SGDT.htm">SIDT</A> instructions.
 If an interrupt occurs and the corresponding
 entry of the interrupt table is beyond the limit stored in the IDTR, the
 processor raises exception 8.

--- a/s14_04.htm
+++ b/s14_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.4</TITLE>
 </HEAD>
@@ -19,12 +19,12 @@ mode.
 
 <H2>14.4.1  Switching to Protected Mode</H2>
 The only way to leave real-address mode is to switch to protected mode. The
-processor enters protected mode when a 
+processor enters protected mode when a
 <A HREF="MOVRS.htm">MOV</A> to CR0 instruction sets the PE
 (protection enable) bit in CR0. (For compatibility with the 80286, the LMSW
 instruction may also be used to set the PE bit.)
 <P>
-Refer to 
+Refer to
 <A HREF="c10.htm">Chapter 10</A>
    "Initialization" for other aspects of switching to
 protected mode.

--- a/s14_05.htm
+++ b/s14_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.5</TITLE>
 </HEAD>
@@ -13,8 +13,8 @@ Chapter 14 -- 80386 Real-Address Mode</A><BR>
 <P>
 <H1>14.5  Switching Back to Real-Address Mode</H1>
 The processor reenters real-address mode if software clears the PE bit in
-CR0 with a 
-<A HREF="MOVRS.htm">MOV</A> to CR0 instruction. 
+CR0 with a
+<A HREF="MOVRS.htm">MOV</A> to CR0 instruction.
 A procedure that attempts to do this,
 however, should proceed as follows:
 <OL>
@@ -38,16 +38,16 @@ appropriate to real mode:
 <LI> Present (P = 1)
 <LI> Base = any value
 </UL>
-<LI> Disable interrupts. A 
+<LI> Disable interrupts. A
 <A HREF="CLI.htm">CLI</A> instruction disables INTR interrupts. NMIs
 can be disabled with external circuitry.
 <LI> Clear the PE bit.
-<LI> Jump to the real mode code to be executed using a far 
+<LI> Jump to the real mode code to be executed using a far
 <A HREF="JMP.htm">JMP</A>. This
 action flushes the instruction queue and puts appropriate values in
 the access rights of the CS register.
-<LI> Use the 
-<A HREF="LGDT.htm">LIDT</A> 
+<LI> Use the
+<A HREF="LGDT.htm">LIDT</A>
 instruction to load the base and limit of the real-mode
 interrupt vector table.
 <LI> Enable interrupts.

--- a/s14_06.htm
+++ b/s14_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.6</TITLE>
 </HEAD>

--- a/s14_07.htm
+++ b/s14_07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.7</TITLE>
 </HEAD>
@@ -27,7 +27,7 @@ The areas most likely to be affected are:
 <LI> Assumed delays with 8086/8088 operating in parallel with an 8087.
 </UL>
 <P>
-<LI> Divide Exceptions Point to the 
+<LI> Divide Exceptions Point to the
 <A HREF="DIV.htm">DIV</A> instruction.
 <P>
 Divide exceptions on the 80386 always leave the saved CS:IP value
@@ -41,10 +41,10 @@ Opcodes that were not defined for the 8086/8088 will cause exception
 6 or will execute one of the new instructions defined for the 80386.
 
 <P>
-<LI> Value written by 
+<LI> Value written by
 <A HREF="PUSH.htm">PUSH</A> SP.
 <P>
-The 80386 pushes a different value on the stack for 
+The 80386 pushes a different value on the stack for
 <A HREF="PUSH.htm">PUSH</A> SP than the
 8086/8088. The 80386 pushes the value of SP before SP is incremented
 as part of the push operation; the 8086/8088 pushes the value of SP
@@ -56,7 +56,7 @@ PUSH  BP
 MOV   BP, SP
 XCHG  BP, [BP]
 </PRE>
-This code functions as the 8086/8088 
+This code functions as the 8086/8088
 <A HREF="PUSH.htm">PUSH</A> SP instruction on the 80386.
 
 <P>
@@ -79,7 +79,7 @@ is violated. The 8086/8088 has no instruction length limit.
 <LI> Operand crossing offset 0 or 65,535.
 <P>
 On the 8086, an attempt to access a memory operand that crosses
-offset 65,535 (e.g., 
+offset 65,535 (e.g.,
 <A HREF="MOV.htm">MOV</A> a word to offset 65,535) or offset 0 (e.g.,
 <A HREF="PUSH.htm">PUSH</A>
 a word when SP = 1) causes the offset to wrap around modulo
@@ -102,27 +102,27 @@ exception 13 in such a case.
 The <A HREF="LOCK.htm">LOCK</A> prefix and its corresponding output signal should only be
 used to prevent other bus masters from interrupting a data movement
 operation. The 80386 always asserts the <A HREF="LOCK.htm">LOCK</A> signal during an XCHG
-instruction with memory (even if the 
-<A HREF="LOCK.htm">LOCK</A> prefix is not used). 
+instruction with memory (even if the
+<A HREF="LOCK.htm">LOCK</A> prefix is not used).
 <A HREF="LOCK.htm">LOCK</A>
 may only be used with the following 80386 instructions when they
-update memory: 
-<A HREF="BTS.htm">BTS</A>, 
-<A HREF="BTR.htm">BTR</A>, 
-<A HREF="BTC.htm">BTC</A>, 
-<A HREF="XCHG.htm">XCHG</A>, 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
-<A HREF="INC.htm">INC</A>, 
+update memory:
+<A HREF="BTS.htm">BTS</A>,
+<A HREF="BTR.htm">BTR</A>,
+<A HREF="BTC.htm">BTC</A>,
+<A HREF="XCHG.htm">XCHG</A>,
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
+<A HREF="INC.htm">INC</A>,
 <A HREF="DEC.htm">DEC</A>,
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
-<A HREF="XOR.htm">XOR</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
+<A HREF="XOR.htm">XOR</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>. An undefined-opcode exception
-(interrupt 6) results from using 
+(interrupt 6) results from using
 <A HREF="LOCK.htm">LOCK</A> before any other instruction.
 
 <P>
@@ -133,7 +133,7 @@ of the 8086/8088. The change prevents an external interrupt handler
 from being single-stepped if the interrupt occurs while a program is
 being single-stepped. The 80386 single-step exception has higher
 priority that any external interrupt. The 80386 will still single-step
-through an interrupt handler invoked by the 
+through an interrupt handler invoked by the
 <A HREF="INT.htm">INT</A> instructions or by an
 exception.
 
@@ -141,13 +141,13 @@ exception.
 <LI> <A HREF="IDIV.htm">IDIV</A> exceptions for quotients of 80H or 8000H.
 <P>
 The 80386 can generate the largest negative number as a quotient for
-the <A HREF="IDIV.htm">IDIV</A> instruction. 
+the <A HREF="IDIV.htm">IDIV</A> instruction.
 The 8086/8088 causes exception zero instead.
 
 <P>
 <LI> Flags in stack.
 <P>
-The setting of the flags stored by 
+The setting of the flags stored by
 <A HREF="PUSHF.htm">PUSHF</A>, by interrupts, and by
 exceptions is different from that stored by the 8086 in bit positions
 12 through 15. On the 8086 these bits are stored as ones, but in
@@ -179,7 +179,7 @@ systems, the saved CS:IP points to the ESC instruction.
 <LI> Coprocessor does not use interrupt controller.
 <P>
 The coprocessor error signal to the 80386 does not pass through an
-interrupt controller (an 8087 
+interrupt controller (an 8087
 <A HREF="INT.htm">INT</A> signal does). Some instructions in
 a coprocessor error handler may need to be deleted if they deal with
 the interrupt controller.

--- a/s14_08.htm
+++ b/s14_08.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.8</TITLE>
 </HEAD>
@@ -21,34 +21,34 @@ The 80286 processor implements the bus lock function differently than the
 80386. Programs that use forms of memory locking specific to the 80286 may
 not execute properly if transported to a specific application of the 80386.
 <P>
-The 
-<A HREF="LOCK.htm">LOCK</A> 
+The
+<A HREF="LOCK.htm">LOCK</A>
 prefix and its corresponding output signal should only be used to
-prevent other bus masters from interrupting a data movement operation.  
+prevent other bus masters from interrupting a data movement operation.
 <A HREF="LOCK.htm">LOCK</A>
 may only be used with the following 80386 instructions when they modify
-memory.  An undefined-opcode exception results from using 
+memory.  An undefined-opcode exception results from using
 <A HREF="LOCK.htm">LOCK</A> before any
 other instruction.
 <UL>
-<LI> Bit test and change: 
-<A HREF="BTS.htm">BTS</A>, 
-<A HREF="BTR.htm">BTR</A>, 
+<LI> Bit test and change:
+<A HREF="BTS.htm">BTS</A>,
+<A HREF="BTR.htm">BTR</A>,
 <A HREF="BTC.htm">BTC</A>.
-<LI> Exchange: 
+<LI> Exchange:
 <A HREF="XCHG.htm">XCHG</A>.
-<LI> One-operand arithmetic and logical: 
-<A HREF="INC.htm">INC</A>, 
-<A HREF="DEC.htm">DEC</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<LI> One-operand arithmetic and logical:
+<A HREF="INC.htm">INC</A>,
+<A HREF="DEC.htm">DEC</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>.
-<LI> Two-operand arithmetic and logical: 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
+<LI> Two-operand arithmetic and logical:
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
 <A HREF="XOR.htm">XOR</A>.
 </UL>
 A locked instruction is guaranteed to lock only the area of memory defined
@@ -73,7 +73,7 @@ RESET than on the 80286. This should not cause compatibility problems,
 because the content of 8086 registers after RESET is undefined.  If
 self-test is requested during the reset sequence and errors are detected in
 the 80386 unit, EAX will contain a nonzero value. EDX contains the component
-and revision identifier . Refer to 
+and revision identifier . Refer to
 <A HREF="c10.htm">Chapter 10</A>
    for more information .
 
@@ -89,5 +89,5 @@ the setting of the undefined, high-order bits.
 <B>up:</B> <A HREF="c14.htm">
 Chapter 14 -- 80386 Real-Address Mode</A><BR>
 <B>prev:</B> <A HREF="s14_07.htm">14.7  Differences From 8086</A><BR>
-<B>next:</B> <A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A> 
+<B>next:</B> <A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A>
 </BODY>

--- a/s15_01.htm
+++ b/s15_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c15.htm">
 Chapter 15 -- Virtual 8086 Mode</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A><BR>
 <B>next:</B> <A HREF="s15_02.htm">15.2  Structure of a V86 Task</A>
 <P>
@@ -41,19 +41,19 @@ introduction of the 80186/80188, 80286 and 80386:
 <LI> New instructions introduced by 80186/80188 and 80286.
 <UL>
 <LI> <A HREF="PUSH.htm">PUSH</A> immediate data
-<LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and 
+<LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and
 <A HREF="POPA.htm">POPA</A>)
 <LI> Multiply immediate data
 <LI> Shift and rotate by immediate count
 <LI> String I/O
-<LI> <A HREF="ENTER.htm">ENTER</A> and 
+<LI> <A HREF="ENTER.htm">ENTER</A> and
 <A HREF="LEAVE.htm">LEAVE</A>
 <LI> <A HREF="BOUND.htm">BOUND</A>
 </UL>
 <LI> New instructions introduced by 80386.
 <UL>
-<LI> <A HREF="LGS.htm">LSS</A>, 
-<A HREF="LGS.htm">LFS</A>, 
+<LI> <A HREF="LGS.htm">LSS</A>,
+<A HREF="LGS.htm">LFS</A>,
 <A HREF="LGS.htm">LGS</A> instructions
 <LI> Long-displacement conditional jumps
 <LI> Single-bit instructions
@@ -70,7 +70,7 @@ In V86 mode, the 80386 processor does not interpret 8086 selectors by
 referring to descriptors; instead, it forms linear addresses as an 8086
 would. It shifts the selector left by four bits to form a 20-bit base
 address. The effective address is extended with four high-order zeros and
-added to the base address to create a linear address as 
+added to the base address to create a linear address as
 <A HREF="s15_01.htm#fig15-1">Figure 15-1</A>
 illustrates.
 <P>
@@ -116,7 +116,7 @@ no error code) occur if an address is generated outside the range 0 through
 <P>
 <B>up:</B> <A HREF="c15.htm">
 Chapter 15 -- Virtual 8086 Mode</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A><BR>
 <B>next:</B> <A HREF="s15_02.htm">15.2  Structure of a V86 Task</A>
 </BODY>

--- a/s15_02.htm
+++ b/s15_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.2</TITLE>
 </HEAD>

--- a/s15_03.htm
+++ b/s15_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.3</TITLE>
 </HEAD>

--- a/s15_04.htm
+++ b/s15_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.4</TITLE>
 </HEAD>
@@ -12,15 +12,15 @@ Chapter 15 -- Virtual 8086 Mode</A><BR>
 <HR>
 <P>
 <H1>15.4  Additional Sensitive Instructions</H1>
-When the 80386 is executing in V86 mode, the instructions 
-<A HREF="PUSHF.htm">PUSHF</A>, 
+When the 80386 is executing in V86 mode, the instructions
+<A HREF="PUSHF.htm">PUSHF</A>,
 <A HREF="POPF.htm">POPF</A>,
-<A HREF="INT.htm">INT n</A>, and 
-<A HREF="IRET.htm">IRET</A> are sensitive to IOPL. The instructions 
-<A HREF="IN.htm">IN</A>, 
-<A HREF="INS.htm">INS</A>, 
+<A HREF="INT.htm">INT n</A>, and
+<A HREF="IRET.htm">IRET</A> are sensitive to IOPL. The instructions
+<A HREF="IN.htm">IN</A>,
+<A HREF="INS.htm">INS</A>,
 <A HREF="OUT.htm">OUT</A>, and
-<A HREF="OUTS.htm">OUTS</A>, 
+<A HREF="OUTS.htm">OUTS</A>,
 which are ordinarily sensitive in protected mode, are not sensitive
 in V86 mode. Following is a complete list of instructions that are sensitive
 in V86 mode:
@@ -38,11 +38,11 @@ will trigger a general-protection exceptions. These instructions are made
 sensitive so that their functions can be simulated by the V86 monitor.
 
 <H2>15.4.1  Emulating 8086 Operating System Calls</H2>
-<A HREF="INT.htm">INT n</A> 
+<A HREF="INT.htm">INT n</A>
 is sensitive so that the V86 monitor can intercept calls to the
 8086 OS. Many 8086 operating systems are called by pushing parameters onto
-the stack, then executing an 
-<A HREF="INT.htm">INT n</A> instruction. If IOPL < 3, 
+the stack, then executing an
+<A HREF="INT.htm">INT n</A> instruction. If IOPL < 3,
 <A HREF="INT.htm">INT n</A>
 instructions will be intercepted by the V86 monitor. The V86 monitor can
 then emulate the function of the 8086 operating system or reflect the
@@ -50,12 +50,12 @@ interrupt back to the 8086 operating system in V86 mode.
 
 <H2>15.4.2  Virtualizing the Interrupt-Enable Flag</H2>
 When the processor is executing 8086 code in a V86 task, the instructions
-<A HREF="PUSHF.htm">PUSHF</A>, 
-<A HREF="POPF.htm">POPF</A>, and 
+<A HREF="PUSHF.htm">PUSHF</A>,
+<A HREF="POPF.htm">POPF</A>, and
 <A HREF="IRET.htm">IRET</A> are sensitive to IOPL so that the V86 monitor can
 control changes to the interrupt-enable flag (IF). Other instructions that
-affect IF 
-(<A HREF="STI.htm">STI</A> and 
+affect IF
+(<A HREF="STI.htm">STI</A> and
 <A HREF="CLI.htm">CLI</A>) are IOPL sensitive both in 8086 code and in
 80386/80386 code.
 <P>

--- a/s15_05.htm
+++ b/s15_05.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.5</TITLE>
 </HEAD>
@@ -33,10 +33,10 @@ or memory mapped.
 <H2>15.5.1  I/O-Mapped I/O</H2>
 I/O-mapped I/O in V86 mode differs from protected mode only in that the
 protection mechanism does not consult IOPL when executing the I/O
-instructions 
-<A HREF="IN.htm">IN</A>, 
-<A HREF="INS.htm">INS</A>, 
-<A HREF="OUT.htm">OUT</A>, 
+instructions
+<A HREF="IN.htm">IN</A>,
+<A HREF="INS.htm">INS</A>,
+<A HREF="OUT.htm">OUT</A>,
 <A HREF="OUTS.htm">OUTS</A>. Only the I/O permission bit map controls
 the right for V86 tasks to execute these I/O instructions.
 <P>
@@ -44,9 +44,9 @@ The I/O permission map traps I/O instructions selectively depending on the
 I/O addresses to which they refer. The I/O permission bit map of each V86
 task determines which I/O addresses are trapped for that task. Because each
 task may have a different I/O permission bit map, the addresses trapped for
-one task may be different from those trapped for others . Refer to 
+one task may be different from those trapped for others . Refer to
 <A HREF="c08.htm">Chapter 8</A>
-  
+
 for more information about the I/O permission map.
 
 <H2>15.5.2  Memory-Mapped I/O</H2>

--- a/s15_06.htm
+++ b/s15_06.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.6</TITLE>
 </HEAD>
@@ -41,7 +41,7 @@ Opcodes that were not defined for the 8086/8088 will cause exception
 
 <LI> Value written by <A HREF="PUSH.htm">PUSH</A> SP.
 
-The 80386 pushes a different value on the stack for 
+The 80386 pushes a different value on the stack for
 <A HREF="PUSH.htm">PUSH</A> SP than the
 8086/8088. The 80386 pushes the value of SP before SP is incremented
 as part of the push operation; the 8086/8088 pushes the value of SP
@@ -52,7 +52,7 @@ PUSH  BP
 MOV   BP, SP
 XCHG  BP, [BP]
 </PRE>
-This code functions as the 8086/8088 
+This code functions as the 8086/8088
 <A HREF="PUSH.htm">PUSH</A> SP instruction on the 80386.
 
 
@@ -75,9 +75,9 @@ is violated. The 8086/8088 has no instruction length limit.
 <LI> Operand crossing offset 0 or 65,535.
 
 On the 8086, an attempt to access a memory operand that crosses
-offset 65,535 (e.g., 
+offset 65,535 (e.g.,
 <A HREF="MOV.htm">MOV</A> a word to offset 65,535) or offset 0 (e.g.,
-<A HREF="PUSH.htm">PUSH</A> a word when SP = 1) 
+<A HREF="PUSH.htm">PUSH</A> a word when SP = 1)
 causes the offset to wrap around modulo
 65,536. The 80386 raises an exception in these -- 13 if
 the segment is a data segment (i.e., if CS, DS, ES, FS, or GS is
@@ -95,33 +95,33 @@ exception 13 in such a case.
 
 <LI> <A HREF="LOCK.htm">LOCK</A> is restricted to certain instructions.
 
-The <A HREF="LOCK.htm">LOCK</A> 
+The <A HREF="LOCK.htm">LOCK</A>
 prefix and its corresponding output signal should only be
 used to prevent other bus masters from interrupting a data movement
-operation. The 80386 always asserts the 
-<A HREF="LOCK.htm">LOCK</A> signal during an 
+operation. The 80386 always asserts the
+<A HREF="LOCK.htm">LOCK</A> signal during an
 <A HREF="XCHG.htm">XCHG</A>
-instruction with memory (even if the 
-<A HREF="LOCK.htm">LOCK</A> prefix is not used). 
+instruction with memory (even if the
+<A HREF="LOCK.htm">LOCK</A> prefix is not used).
 <A HREF="LOCK.htm">LOCK</A>
 may only be used with the following 80386 instructions when they
-update memory: 
-<A HREF="BTS.htm">BTS</A>, 
-<A HREF="BTR.htm">BTR</A>, 
-<A HREF="BTC.htm">BTC</A>, 
-<A HREF="XCHG.htm">XCHG</A>, 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
-<A HREF="INC.htm">INC</A>, 
+update memory:
+<A HREF="BTS.htm">BTS</A>,
+<A HREF="BTR.htm">BTR</A>,
+<A HREF="BTC.htm">BTC</A>,
+<A HREF="XCHG.htm">XCHG</A>,
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
+<A HREF="INC.htm">INC</A>,
 <A HREF="DEC.htm">DEC</A>,
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
-<A HREF="XOR.htm">XOR</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
+<A HREF="XOR.htm">XOR</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>. An undefined-opcode exception (interrupt
-6) results from using 
+6) results from using
 <A HREF="LOCK.htm">LOCK</A> before any other instruction.
 
 
@@ -132,7 +132,7 @@ that of the 8086/8088. The change prevents an external interrupt
 handler from being single-stepped if the interrupt occurs while a
 program is being single-stepped. The 80386 single-step exception has
 higher priority that any external interrupt. The 80386 will still
-single-step through an interrupt handler invoked by the 
+single-step through an interrupt handler invoked by the
 <A HREF="INT.htm">INT</A>
 instructions or by an exception.
 
@@ -140,14 +140,14 @@ instructions or by an exception.
 <LI> <A HREF="IDIV.htm">IDIV</A> exceptions for quotients of 80H or 8000H.
 
 The 80386 can generate the largest negative number as a quotient for
-the 
-<A HREF="IDIV.htm">IDIV</A> instruction. 
+the
+<A HREF="IDIV.htm">IDIV</A> instruction.
 The 8086/8088 causes exception zero instead.
 
 
 <LI> Flags in stack.
 
-The setting of the flags stored by 
+The setting of the flags stored by
 <A HREF="PUSHF.htm">PUSHF</A>, by interrupts, and by
 exceptions is different from that stored by the 8086 in bit positions
 12 through 15. On the 8086 these bits are stored as ones, but in V86
@@ -179,7 +179,7 @@ systems, the saved CS:IP points to the ESC instruction itself.
 <LI> Coprocessor does not use interrupt controller.
 
 The coprocessor error signal to the 80386 does not pass through an
-interrupt controller (an 8087 
+interrupt controller (an 8087
 <A HREF="INT.htm">INT</A> signal does). Some instructions in
 a coprocessor error handler may need to be deleted if they deal with
 the interrupt controller.

--- a/s15_07.htm
+++ b/s15_07.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.7</TITLE>
 </HEAD>
@@ -15,41 +15,41 @@ Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A>
 <H1>15.7  Differences From 80286 Real-Address Mode</H1>
 The 80286 processor implements the bus lock function differently than the
 80386. This fact may or may not be apparent to 8086 programs, depending on
-how the V86 monitor handles the <A HREF="LOCK.htm">LOCK</A> prefix. 
+how the V86 monitor handles the <A HREF="LOCK.htm">LOCK</A> prefix.
 <A HREF="LOCK.htm">LOCK</A>ed instructions are
 sensitive to IOPL; therefore, software designers can choose to emulate its
-function. If, however, 8086 programs are allowed to execute 
+function. If, however, 8086 programs are allowed to execute
 <A HREF="LOCK.htm">LOCK</A> directly,
 programs that use forms of memory locking specific to the 8086 may not
 execute properly when transported to a specific application of the 80386.
 <P>
-The <A HREF="LOCK.htm">LOCK</A> 
+The <A HREF="LOCK.htm">LOCK</A>
 prefix and its corresponding output signal should only be used to
-prevent other bus masters from interrupting a data movement operation. 
+prevent other bus masters from interrupting a data movement operation.
 <A HREF="LOCK.htm">LOCK</A>
 may only be used with the following 80386 instructions when they modify
-memory. An undefined-opcode exception results from using 
+memory. An undefined-opcode exception results from using
 <A HREF="LOCK.htm">LOCK</A> before any
 other instruction.
 <UL>
-<LI> Bit test and change: 
-<A HREF="BTS.htm">BTS</A>, 
-<A HREF="BTR.htm">BTR</A>, 
+<LI> Bit test and change:
+<A HREF="BTS.htm">BTS</A>,
+<A HREF="BTR.htm">BTR</A>,
 <A HREF="BTC.htm">BTC</A>.
-<LI> Exchange: 
+<LI> Exchange:
 <A HREF="XCHG.htm">XCHG</A>.
-<LI> One-operand arithmetic and logical: 
-<A HREF="INC.htm">INC</A>, 
-<A HREF="DEC.htm">DEC</A>, 
-<A HREF="NOT.htm">NOT</A>, and 
+<LI> One-operand arithmetic and logical:
+<A HREF="INC.htm">INC</A>,
+<A HREF="DEC.htm">DEC</A>,
+<A HREF="NOT.htm">NOT</A>, and
 <A HREF="NEG.htm">NEG</A>.
-<LI> Two-operand arithmetic and logical: 
-<A HREF="ADD.htm">ADD</A>, 
-<A HREF="ADC.htm">ADC</A>, 
-<A HREF="SUB.htm">SUB</A>, 
-<A HREF="SBB.htm">SBB</A>, 
-<A HREF="AND.htm">AND</A>, 
-<A HREF="OR.htm">OR</A>, 
+<LI> Two-operand arithmetic and logical:
+<A HREF="ADD.htm">ADD</A>,
+<A HREF="ADC.htm">ADC</A>,
+<A HREF="SUB.htm">SUB</A>,
+<A HREF="SBB.htm">SBB</A>,
+<A HREF="AND.htm">AND</A>,
+<A HREF="OR.htm">OR</A>,
 <A HREF="XOR.htm">XOR</A>.
 </UL>
 A locked instruction is guaranteed to lock only the area of memory defined

--- a/s16_01.htm
+++ b/s16_01.htm
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 16.1</TITLE>
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c16.htm">
 Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A><BR>
-<B>prev:</B> 
+<B>prev:</B>
 <A HREF="c16.htm">Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A><BR>
 <B>next:</B> <A HREF="s16_02.htm">16.2  Mixing 32-Bit and 16-Bit Operations</A>
 <P>

--- a/s16_02.htm
+++ b/s16_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 16.2</TITLE>
 </HEAD>
@@ -56,7 +56,7 @@ code segment is based upon these criteria:
 <LI> The need to address instructions or data in segments that are larger
 than 64 Kilobytes.
 <LI> The predominant size of operands.
-<LI> The addressing modes desired. (Refer to 
+<LI> The addressing modes desired. (Refer to
 <A HREF="c17.htm">Chapter 17</A> for an explanation
 of the additional addressing modes that are available when 32-bit
 addressing is used.)

--- a/s16_03.htm
+++ b/s16_03.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 16.3</TITLE>
 </HEAD>
@@ -35,11 +35,11 @@ The B-bit of a stack segment cannot, in general, be used to change the size
 of stack used by a USE16 code segment. The size of stack pointer used by the
 processor for implicit stack references is controlled by the B-bit of the
 data-segment descriptor for the stack. Implicit references are those caused
-by interrupts, exceptions, and instructions such as 
-<A HREF="PUSH.htm">PUSH</A>, 
-<A HREF="POP.htm">POP</A>, 
+by interrupts, exceptions, and instructions such as
+<A HREF="PUSH.htm">PUSH</A>,
+<A HREF="POP.htm">POP</A>,
 <A HREF="CALL.htm">CALL</A>, and
-<A HREF="RET.htm">RET</A>. 
+<A HREF="RET.htm">RET</A>.
 One might be tempted, therefore, to try to increase beyond 64K the
 size of the stack used by 16-bit code simply by supplying a larger stack
 segment with the B-bit set. However, the B-bit does not control explicit
@@ -50,7 +50,7 @@ prefix, causing those references to use 32-bit addressing.
 <P>
 In big, expand-down segments (B=1, G=1, and E=1), all offsets are greater
 than 64K, therefore USE16 code cannot utilize such a stack segment unless
-the code segment is modified to employ 32-bit addressing . (Refer to 
+the code segment is modified to employ 32-bit addressing . (Refer to
 <A HREF="c06.htm">Chapter 6</A>
    for a review of the B , G, and E bits .)
 <P>

--- a/s16_04.htm
+++ b/s16_04.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 16.4</TITLE>
 </HEAD>
@@ -9,7 +9,7 @@ Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A><BR>
 <B>prev:</B>
 <A HREF="s16_03.htm">
 16.3  Sharing Data Segments Among Mixed Code Segments</A><BR>
-<B>next:</B> 
+<B>next:</B>
 <A HREF="c17.htm">Chapter 17 -- 80386 Instruction Set</A><BR>
 <P>
 <HR>
@@ -49,11 +49,11 @@ interface procedure are discussed later in this chapter.
 
 <H2>16.4.2  Stack Management for Control Transfers</H2>
 Because stack management is different for 16-bit <A HREF="CALL.htm">CALL</A>/<A HREF="RET.htm">RET</A> than for 32-bit
-<A HREF="CALL.htm">CALL</A>/<A HREF="RET.htm">RET</A>, the operand size of <A HREF="RET.htm">RET</A> must match that of 
-<A HREF="CALL.htm">CALL</A>. (Refer to 
+<A HREF="CALL.htm">CALL</A>/<A HREF="RET.htm">RET</A>, the operand size of <A HREF="RET.htm">RET</A> must match that of
+<A HREF="CALL.htm">CALL</A>. (Refer to
 <A HREF="s16_04.htm#fig16-1">Figure 16-1</A>
   .) A 16-bit <A HREF="CALL.htm">CALL</A> pushes the 16-bit IP and
-(for calls between privilege levels) 
+(for calls between privilege levels)
 the 16-bit SP register. The corresponding <A HREF="RET.htm">RET</A> must also use a 16-bit
 operand size to <A HREF="POP.htm">POP</A> these 16-bit values from the stack into the 16-bit
 registers. A 32-bit <A HREF="CALL.htm">CALL</A> pushes the 32-bit EIP and (for interlevel calls)
@@ -238,5 +238,5 @@ Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A><BR>
 <A HREF="s16_03.htm">
 16.3  Sharing Data Segments Among Mixed Code Segments</A><BR>
 <B>next:</B> <A HREF="s16_03.htm">
-<A HREF="c17.htm">Chapter 17 -- 80386 Instruction Set</A><BR> 
+<A HREF="c17.htm">Chapter 17 -- 80386 Instruction Set</A><BR>
 </BODY>

--- a/s17_01.htm
+++ b/s17_01.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 17.1</TITLE>
 </HEAD>

--- a/s17_02.htm
+++ b/s17_02.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 17.2</TITLE>
 </HEAD>
@@ -8,14 +8,14 @@
 Chapter 17 -- 80386 Instruction Set</A><BR>
 <B>prev:</B> <A HREF="s17_01.htm">
 17.1 Operand Size and Address-Size Attributes</A><BR>
-<B>next:</B> <A HREF="AAA.htm"> AAA ASCII Adjust after Addition</A> 
+<B>next:</B> <A HREF="AAA.htm"> AAA ASCII Adjust after Addition</A>
 <P>
 <HR>
 <P>
 <H1>17.2  Instruction Format</H1>
 
 All instruction encodings are subsets of the general instruction format
-shown in 
+shown in
 <A HREF="s17_02.htm#fig17-1">Figure 17-1</A>
   . Instructions consist of optional instruction
 prefixes, one or two primary opcode bytes, possibly an address specifier
@@ -102,7 +102,7 @@ instructions. They contain the following information:
 The ModR/M byte contains three fields of information:
 
 <UL>
- <LI> The mod field, which occupies the two most significant bits of the 
+ <LI> The mod field, which occupies the two most significant bits of the
      byte, combines with the r/m field to form 32 possible values: eight
      registers and 24 indexing modes
 
@@ -171,7 +171,7 @@ r32(/r)                    EAX   ECX   EDX   EBX   ESP   EBP   ESI   EDI
 /digit (Opcode)            0     1     2     3     4     5     6     7
 REG =                      000   001   010   011   100   101   110   111
 
-   Effective 
+   Effective
 +---Address--+ +Mod R/M+ +--------ModR/M Values in Hexadecimal--------+
 
 [BX + SI]            000   00    08    10    18    20    28    30    38
@@ -367,31 +367,31 @@ other than hexadecimal bytes are as follows:
 
 <DL>
 <DT>
-/digit: 
+/digit:
 <DD>(digit is between 0 and 7) indicates that the ModR/M byte of the
 instruction uses only the r/m (register or memory) operand. The reg field
 contains the digit that provides an extension to the instruction's opcode.
 
 <DT>
-/r: 
+/r:
 <DD>indicates that the ModR/M byte of the instruction contains both a
 register operand and an r/m operand.
 
 <DT>
-cb, cw, cd, cp: 
+cb, cw, cd, cp:
 <DD>a 1-byte (cb), 2-byte (cw), 4-byte (cd) or 6-byte (cp)
 value following the opcode that is used to specify a code offset and
 possibly a new value for the code segment register.
 
 <DT>
-ib, iw, id: 
+ib, iw, id:
 <DD>a 1-byte (ib), 2-byte (iw), or 4-byte (id) immediate operand to
 the instruction that follows the opcode, ModR/M bytes or scale-indexing
 bytes. The opcode determines if the operand is a signed value. All words and
 doublewords are given with the low-order byte first.
 
 <DT>
-+rb, +rw, +rd: 
++rb, +rw, +rd:
 <DD>a register code, from 0 through 7, added to the hexadecimal
 byte given at the left of the plus sign to form a single opcode byte. The
 codes are
@@ -417,19 +417,19 @@ used to represent operands in the instruction statements:
 
 <DL>
 <DT>
-rel8: 
+rel8:
 <DD>a relative address in the range from 128 bytes before the end of the
 instruction to 127 bytes after the end of the instruction.
 
 <DT>
-rel16, rel32: 
+rel16, rel32:
 <DD>a relative address within the same code segment as the
 instruction assembled. rel16 applies to instructions with an operand-size
 attribute of 16 bits; rel32 applies to instructions with an operand-size
 attribute of 32 bits.
 
 <DT>
-ptr16:16, ptr16:32: 
+ptr16:16, ptr16:32:
 <DD>a FAR pointer, typically in a code segment different
 from that of the instruction. The notation 16:16 indicates that the value of
 the pointer has two parts. The value to the right of the colon is a 16-bit
@@ -439,92 +439,92 @@ used when the instruction's operand-size attribute is 16 bits; ptr16:32 is
 used with the 32-bit attribute.
 
 <DT>
-r8: 
+r8:
 <DD>one of the byte registers AL, CL, DL, BL, AH, CH, DH, or BH.
 
 <DT>
-r16: 
+r16:
 <DD>one of the word registers AX, CX, DX, BX, SP, BP, SI, or DI.
 
 <DT>
-r32: 
+r32:
 <DD>one of the doubleword registers EAX, ECX, EDX, EBX, ESP, EBP, ESI, or
 EDI.
 
 <DT>
-imm8: 
+imm8:
 <DD>an immediate byte value. imm8 is a signed number between -128 and
 +127 inclusive. For instructions in which imm8 is combined with a word or
 doubleword operand, the immediate value is sign-extended to form a word or
 doubleword. The upper byte of the word is filled with the topmost bit of the
 immediate value.
 
-<DT>imm16: 
+<DT>imm16:
 <DD>an immediate word value used for instructions whose operand-size
 attribute is 16 bits. This is a number between -32768 and +32767 inclusive.
 
 <DT>
-imm32: 
+imm32:
 <DD>an immediate doubleword value used for instructions whose
 operand-size attribute is 32-bits. It allows the use of a number between
 +2147483647 and -2147483648.
 
 <DT>
-r/m8: 
+r/m8:
 <DD>a one-byte operand that is either the contents of a byte register
 (AL, BL, CL, DL, AH, BH, CH, DH), or a byte from memory.
 
 <DT>
-r/m16: 
+r/m16:
 <DD>a word register or memory operand used for instructions whose
 operand-size attribute is 16 bits. The word registers are: AX, BX, CX, DX,
 SP, BP, SI, DI. The contents of memory are found at the address provided by
 the effective address computation.
 
 <DT>
-r/m32: 
+r/m32:
 <DD>a doubleword register or memory operand used for instructions whose
 operand-size attribute is 32-bits. The doubleword registers are: EAX, EBX,
 ECX, EDX, ESP, EBP, ESI, EDI. The contents of memory are found at the
 address provided by the effective address computation.
 
 <DT>
-m8: 
+m8:
 <DD>a memory byte addressed by DS:SI or ES:DI (used only by string
 instructions).
 
 <DT>
-m16: 
+m16:
 <DD>a memory word addressed by DS:SI or ES:DI (used only by string
 instructions).
 
 <DT>
-m32: 
+m32:
 <DD>a memory doubleword addressed by DS:SI or ES:DI (used only by string
 instructions).
 
 <DT>
-m16:16, M16:32: 
+m16:16, M16:32:
 <DD>a memory operand containing a far pointer composed of two
 numbers. The number to the left of the colon corresponds to the pointer's
 segment selector. The number to the right corresponds to its offset.
 
 <DT>
-m16 & 32, m16 & 16, m32 & 32: 
+m16 & 32, m16 & 16, m32 & 32:
 <DD>a memory operand consisting of data item pairs
 whose sizes are indicated on the left and the right side of the ampersand.
 All memory addressing modes are allowed. m16 & 16 and m32 & 32 operands are
 used by the <A HREF="BOUND.htm">BOUND</A> instruction to provide an operand containing an upper and
-lower bounds for array indices. m16 & 32 is used by 
+lower bounds for array indices. m16 & 32 is used by
 <A HREF="LGDT.htm">LIDT</A> and <A HREF="LGDT.htm">LGDT</A> to
 provide a word with which to load the limit field, and a doubleword with
 which to load the base field of the corresponding Global and Interrupt
 Descriptor Table Registers.
 
 <DT>
-moffs8, moffs16, moffs32: 
+moffs8, moffs16, moffs32:
 <DD>(memory offset) a simple memory variable of type
-BYTE, WORD, or DWORD used by some variants of the 
+BYTE, WORD, or DWORD used by some variants of the
 <A HREF="MOV.htm">MOV</A> instruction. The
 actual address is given by a simple offset relative to the segment base. No
 ModR/M byte is used in the instruction. The number shown with moffs
@@ -532,7 +532,7 @@ indicates its size, which is determined by the address-size attribute of the
 instruction.
 
 <DT>
-Sreg: 
+Sreg:
 <DD>a segment register. The segment register bit assignments are ES=0,
 CS=1, SS=2, DS=3, FS=4, and GS=5.
 </DL>
@@ -782,7 +782,7 @@ The following functions are used in the algorithmic descriptions:
 <P>
    If the base operand is a register, the offset can be in the range 0..31.
    This offset addresses a bit within the indicated register. An example,
-   "BIT[EAX, 21]," is illustrated in 
+   "BIT[EAX, 21]," is illustrated in
 <A HREF="s17_02.htm#fig17-3">Figure 17-3</A>
   .
 <P>
@@ -790,7 +790,7 @@ The following functions are used in the algorithmic descriptions:
    gigabits. The addressed bit is numbered (Offset MOD 8) within the byte at
    address (BitBase + (BitOffset DIV 8)), where DIV is signed division with
    rounding towards negative infinity, and MOD returns a positive number.
-   This is illustrated in 
+   This is illustrated in
 <A HREF="s17_02.htm#fig17-4">Figure 17-4</A>
   .
 
@@ -816,7 +816,7 @@ The following functions are used in the algorithmic descriptions:
    FI;
 </PRE>
 
- <LI> Switch-Tasks is the task switching function described in 
+ <LI> Switch-Tasks is the task switching function described in
  <A HREF="c07.htm">Chapter 7</A>.
  </LI>
 </UL>
@@ -919,7 +919,7 @@ Mnemonic     Interrupt    Description
 <H3>17.2.2.9  Real Address Mode Exceptions</H3>
 
 Because less error checking is performed by the 80386 in Real Address Mode,
-this mode has fewer exception conditions . Refer to 
+this mode has fewer exception conditions . Refer to
 <A HREF="c14.htm">Chapter 14</A>
    for further
 information on these exceptions.
@@ -929,7 +929,7 @@ information on these exceptions.
 
 Virtual 8086 tasks provide the ability to simulate Virtual 8086 machines.
 Virtual 8086 Mode exceptions are similar to those for the 8086 processor,
-but there are some differences . Refer to 
+but there are some differences . Refer to
 <A HREF="c15.htm">Chapter 15</A>
    for details .
 <P>

--- a/toc.htm
+++ b/toc.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
-<HTML>
+<HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Table of Contents</TITLE>
 </HEAD>
@@ -107,7 +107,7 @@ Table of Contents</H2>
 </UL>
 <H2><A HREF="PIII.htm">Part III Compatibility</A></H2>
 <H3><A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A></H3>
-<UL> 
+<UL>
 <LI> <A HREF="s13_01.htm">13.1 80286 Code Executes as a Subset of the 80386</A>
 <LI> <A HREF="s13_02.htm">13.2 Two ways to Execute 80286 Tasks</A><BR>
 <LI> <A HREF="s13_03.htm">13.3  Differences From 80286</A>
@@ -122,7 +122,7 @@ Table of Contents</H2>
 <LI> <A HREF="s14_06.htm">14.6 Real-Address Mode Exceptions</A><BR>
 <LI> <A HREF="s14_07.htm">14.7 Differences From 8086</A><BR>
 <LI> <A HREF="s14_08.htm">14.8  Differences From 80286 Real-Address Mode</A>
-</UL> 
+</UL>
 <H3><A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A></H3>
 <UL>
 <LI> <A HREF="s15_01.htm">15.1 Executing 8086 Code</A><BR>
@@ -137,7 +137,7 @@ Table of Contents</H2>
 <UL>
 <LI> <A HREF="s16_01.htm">16.1 How the 80386 Implements 16-Bit and 32-Bit Features</A><BR>
 <LI> <A HREF="s16_02.htm">16.2 Mixing 32-Bit and 16-Bit Operations</A><BR>
-<LI> 
+<LI>
 <A HREF="s16_03.htm">16.3  Sharing Data Segments Among Mixed Code Segments</A>
 <LI> <A HREF="s16_04.htm">
 16.4  Transferring Control Among Mixed Code Segments></A>
@@ -160,4 +160,3 @@ Table of Contents</H2>
 <A HREF="appd.htm">Appendix D -- Condition Codes</A>
 </UL>
 </BODY>
-


### PR DESCRIPTION
In the course of checking accessibility of my course materials, I found that the manual page doesn't specify the language.  It is a simple search/replace fix to add this to help users with vision and other impairments.

https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html