### PR TITLE
Disambiguate link text for MOV and MOVRS

### DIFF
--- a/appa.htm
+++ b/appa.htm
@@ -37,12 +37,12 @@ character, a lowercase letter, specifies the type of operand.
 
 <DT>C
 <DD>The reg field of the modR/M byte selects a control register; e.g.,
-<A HREF="MOVRS.htm">MOV</A>
+<A HREF="MOVRS.htm">MOVRS</A>
    (0F20, 0F22).
 
 <DT>D
 <DD>The reg field of the modR/M byte selects a debug register; e.g.,
-<A HREF="MOVRS.htm">MOV</A>
+<A HREF="MOVRS.htm">MOVRS</A>
    (0F21,0F23).
 
 <DT>E
@@ -92,7 +92,7 @@ character, a lowercase letter, specifies the type of operand.
 
 <DT>T
 <DD>The reg field of the modR/M byte selects a test register; e.g.,
-<A HREF="MOVRS.htm">MOV</A>
+<A HREF="MOVRS.htm">MOVRS</A>
    (0F24,0F26).
 
 <DT>X
@@ -235,7 +235,7 @@ F|  <A HREF="LOCK.htm">LOCK</A>   |         |  <A HREF="REP.htm">REPNE</A>  |   
 1|         |         |         |         |         |         |        |        |         |         |         |         |         |         |        |        |
  |         |         |         |         |         |         |        |        |         |         |         |         |         |         |        |        |
  +---------+---------+---------+---------+---------+---------+--------+--------+---------+---------+---------+---------+---------+---------+--------+--------+
- |   <A HREF="MOVRS.htm">MOV</A>   |   <A HREF="MOVRS.htm">MOV</A>   |   <A HREF="MOVRS.htm">MOV</A>   |   <A HREF="MOVRS.htm">MOV</A>   |   <A HREF="MOVRS.htm">MOV</A>   |         |   <A HREF="MOVRS.htm">MOV</A>  |        |         |         |         |         |         |         |        |        |
+ |   <A HREF="MOVRS.htm">MOVRS</A>   |   <A HREF="MOVRS.htm">MOVRS</A>   |   <A HREF="MOVRS.htm">MOVRS</A>   |   <A HREF="MOVRS.htm">MOVRS</A>   |   <A HREF="MOVRS.htm">MOVRS</A>   |         |   <A HREF="MOVRS.htm">MOVRS</A>  |        |         |         |         |         |         |         |        |        |
 2|         |         |         |         |         |         |        |        |         |         |         |         |         |         |        |        |
  |  Cd,Rd  |  Dd,Rd  |  Rd,Cd  |  Rd,Dd  |  Td,Rd  |         |  Rd,Td |        |         |         |         |         |         |         |        |        |
  +---------+---------+---------+---------+---------+---------+--------+--------+---------+---------+---------+---------+---------+---------+--------+--------+


### PR DESCRIPTION
This addresses a level A accessibility issue (different link targets with same text) in this manual.