### PR TITLE
Set the minimum height for interactive elements

### DIFF
--- a/c01.htm
+++ b/c01.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 01</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -21,7 +22,7 @@ memory-management facilities include address translation registers,
 advanced multitasking hardware, a protection mechanism, and paged virtual
 memory. Special debugging registers provide data and code breakpoints even
 in ROM-based software.
-<P>
+<P class="shortcuts">
 <A HREF="s01_01.htm">1.1  Organization of This Manual</A><BR>
 <A HREF="s01_02.htm">1.2  Related Literature</A><BR>
 <A HREF="s01_03.htm">1.3  Notational Conventions</A><BR>

--- a/c02.htm
+++ b/c02.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 02</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -38,7 +39,7 @@ system. For this reason, the I/O features of the 80386 are discussed in
 <P>
 This chapter contains a section for each aspect of the architecture that is
 normally visible to applications.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s02_01.htm">2.1  Memory Organization and Segmentation</A><BR>
 <A HREF="s02_02.htm">2.2  Data Types</A><BR>
 <A HREF="s02_03.htm">2.3  Registers</A><BR>

--- a/c03.htm
+++ b/c03.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 03</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <P>
@@ -39,7 +40,7 @@ The instruction dictionary in
    contains more detailed
 descriptions of all instructions, including encoding, operation, timing,
 effect on flags, and exceptions.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s03_01.htm">3.1  Data Movement Instructions</A><BR>
 <A HREF="s03_02.htm">3.2  Binary Arithmetic Instructions</A><BR>
 <A HREF="s03_03.htm">3.3  Decimal Arithmetic Instructions</A><BR>

--- a/c04.htm
+++ b/c04.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 04</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <P>
@@ -36,7 +37,7 @@ chapters of Part II in perspective. Each mention in this chapter of a
 register or instruction is either accompanied by an explanation or a
 reference to a following chapter where detailed information can be obtained.
 
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s04_01.htm">4.1  Systems Registers</A><BR>
 <A HREF="s04_02.htm">4.2  Systems Instructions</A>
 <P>

--- a/c05.htm
+++ b/c05.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 05</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -65,7 +66,7 @@ the subject of protection is taken up in another chapter,
             ADDRESS  |                              |
                      +------------------------------+
 </PRE>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s05_01.htm">5.1  Segment Translation</A><BR>
 <A HREF="s05_02.htm">5.2  Page Translation</A><BR>
 <A HREF="s05_03.htm">5.3  Combining Segment and Page Translation</A>

--- a/c06.htm
+++ b/c06.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 06</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -13,7 +14,7 @@ Table of Contents</A><BR>
 <HR>
 <P>
 <H1>Chapter 6  Protection</H1>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s06_01.htm">6.1  Why Protection?</A><BR>
 <A HREF="s06_02.htm">6.2  Overview of 80386 Protection Mechanisms</A><BR>
 <A HREF="s06_03.htm">6.3  Segment-Level Protection</A><BR>

--- a/c07.htm
+++ b/c07.htm
@@ -45,7 +45,7 @@ other task-management features:
       mapping. This is yet another protection feature, because tasks can be
       isolated and prevented from interfering with one another.
 </OL>
-<P CLASS="SHORTCUT">
+<P CLASS="SHORTCUTS">
 <A HREF="s07_01.htm">7.1  Task State Segment</A><BR>
 <A HREF="s07_02.htm">7.2  TSS Descriptor</A><BR>
 <A HREF="s07_03.htm">7.3  Task Register</A><BR>

--- a/c07.htm
+++ b/c07.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 07</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <P>
@@ -44,7 +45,7 @@ other task-management features:
       mapping. This is yet another protection feature, because tasks can be
       isolated and prevented from interfering with one another.
 </OL>
-<P>
+<P CLASS="SHORTCUT">
 <A HREF="s07_01.htm">7.1  Task State Segment</A><BR>
 <A HREF="s07_02.htm">7.2  TSS Descriptor</A><BR>
 <A HREF="s07_03.htm">7.3  Task Register</A><BR>

--- a/c08.htm
+++ b/c08.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 08</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <P>
@@ -24,7 +25,7 @@ perspectives:
 <LI>Protection as it applies to the use of I/O instructions and I/O port
      addresses.
 </UL>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s08_01.htm">8.1  I/O Addressing</A><BR>
 <A HREF="s08_02.htm">8.2  I/O Instructions</A><BR>
 <A HREF="s08_03.htm">8.3  Protection and I/O</A>

--- a/c09.htm
+++ b/c09.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 09</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -48,7 +49,7 @@ exceptions:
 </OL>
 This chapter explains the features that the 80386 offers for controlling
 and responding to interrupts when it is executing in protected mode.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s09_01.htm">9.1  Identifying Interrupts</A><BR>
 <A HREF="s09_02.htm">9.2  Enabling and Disabling Interrupts</A><BR>
 <A HREF="s09_03.htm">

--- a/c10.htm
+++ b/c10.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 10</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -17,7 +18,7 @@ After a signal on the RESET pin, certain registers of the 80386 are set to
 predefined values. These values are adequate to enable execution of a
 bootstrap program, but additional initialization must be performed by
 software before all the features of the processor can be utilized.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s10_01.htm">10.1  Processor State After Reset</A><BR>
 <A HREF="s10_02.htm">
 10.2  Software Initialization for Real-Address Mode</A><BR>

--- a/c11.htm
+++ b/c11.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 11</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -21,7 +22,7 @@ The 80386 has two levels of support for multiple parallel processing units:
 <LI>A more general interface for more loosely coupled processors of
      unspecified type.
 </UL>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s11_01.htm">11.1  Coprocessing</A><BR>
 <A HREF="s11_02.htm">11.2  General Multiprocessing</A>
 <P>

--- a/c12.htm
+++ b/c12.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 12</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -26,7 +27,7 @@ associated with writing a breakpoint instruction into a code segment
 (requires a data-segment alias for the code segment) or a code segment
 shared by multiple tasks (the breakpoint exception can occur in the context
 of any of the tasks). Breakpoints can even be set in code contained in ROM.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s12_01.htm">12.1  Debugging Features of the Architecture</A><BR>
 <A HREF="s12_02.htm">12.2  Debug Registers</A><BR>
 <A HREF="s12_03.htm">12.3  Debug Exceptions</A>

--- a/c13.htm
+++ b/c13.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 13</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -13,7 +14,7 @@ Table of Contents</A><BR>
 <HR>
 <P>
 <H1>Chapter 13  Executing 80286 Protected-Mode Code</H1>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s13_01.htm">13.1  80286 Code Executes as a Subset of the 80386</A><BR>
 <A HREF="s13_02.htm">13.2  Two ways to Execute 80286 Tasks</A><BR>
 <A HREF="s13_03.htm">13.3  Differences From 80286</A>

--- a/c14.htm
+++ b/c14.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 14</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">

--- a/c14.htm
+++ b/c14.htm
@@ -36,7 +36,7 @@ programmer's view of the 80386 in real-address mode:
 <LI>Differences from 8086.
 <LI>Differences from 80286 real-address mode.
 </UL>
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s14_01.htm">14.1  Physical Address Formation</A><BR>
 <A HREF="s14_02.htm">14.2  Registers and Instructions</A><BR>
 <A HREF="s14_03.htm">14.3  Interrupt and Exception Handling</A><BR>

--- a/c15.htm
+++ b/c15.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 15</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -39,7 +40,7 @@ is the result of cooperation between hardware and software:
 </UL>
 Software that helps implement virtual 8086 machines is called a V86
 monitor.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s15_01.htm">15.1  Executing 8086 Code</A><BR>
 <A HREF="s15_02.htm">15.2  Structure of a V86 Task</A><BR>
 <A HREF="s15_03.htm">15.3  Entering and Leaving V86 Mode</A><BR>

--- a/c16.htm
+++ b/c16.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 16</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -80,7 +81,7 @@ On the 80386, 16-bit modules can be mixed with 32-bit modules. To design a
 system that mixes 16- and 32-bit code requires an understanding of the
 mechanisms that the 80386 uses to invoke and control its 32-bit and 16-bit
 features.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s16_01.htm">
 16.1  How the 80386 Implements 16-Bit and 32-Bit Features</A><BR>
 <A HREF="s16_02.htm">16.2  Mixing 32-Bit and 16-Bit Operations</A><BR>

--- a/c17.htm
+++ b/c17.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Chapter 17</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="toc.htm">
@@ -21,7 +22,7 @@ each instruction, the forms are given for each operand combination,
 including object code produced, operands required, execution time, and a
 description. For each instruction, there is an operational description and a
 summary of exceptions generated.
-<P>
+<P CLASS="SHORTCUTS">
 <A HREF="s17_01.htm">17.1  Operand-Size and Address-Size Attributes</A>
 <BR><A HREF="s17_02.htm">17.2 Instruction Format</A>
 

--- a/s01_01.htm
+++ b/s01_01.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 1.1</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c01.htm">
@@ -13,7 +14,7 @@ Chapter 1 -- Introduction to the 80386</A><BR>
 <P>
 <H1>1.1  Organization of This Manual</H1>
 This book presents the architecture of the 80386 in five parts:
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="PI.htm">Part I -- Applications Programming</A>
 <LI><A HREF="PII.htm">Part II -- Systems Programming</A>
 <LI><A HREF="PIII.htm">Part III -- Compatibility</A>
@@ -31,13 +32,13 @@ instructions as they relate to specific purposes or to specific
 architectural features.
 <DL><BR>
 <DT>Explanation
-<DD><UL>
+<DD><UL CLASS="SHORTCUTS">
 <LI><A HREF="PI.htm">Part I -- Applications Programming</A>
 <LI><A HREF="PII.htm">Part II -- Systems Programming</A>
 <LI><A HREF="PIII.htm">Part III -- Compatibility</A>
 </UL>
 <DT>Reference
-<DD><UL>
+<DD><UL CLASS="SHORTCUTS">
 <LI><A HREF="PIV.htm">Part IV -- Instruction Set</A>
 <LI><A HREF="https://css.csail.mit.edu/6.858/2014/readings/i386/APP.htm">Appendices</A>
 </UL>

--- a/s03_10.htm
+++ b/s03_10.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 3.10</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c03.htm">
@@ -19,7 +20,7 @@ instructions is used by applications programmers. The instructions that deal
 with segment registers are:
 <OL>
 <LI> Segment-register transfer instructions.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="MOV.htm">MOV</A> SegReg, ...
 <LI><A HREF="MOV.htm">MOV</A> ..., SegReg
 <LI><A HREF="PUSH.htm">PUSH</A> SegReg
@@ -27,14 +28,14 @@ with segment registers are:
 </UL>
 
 <LI> Control transfers to another executable segment.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="JMP.htm">JMP</A> far direct and indirect
 <LI><A HREF="CALL.htm">CALL</A> far
 <LI><A HREF="RET.htm">RET</A> far
 </UL>
 
 <LI> Data pointer instructions.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="LGS.htm">LDS</A>
 <LI><A HREF="LGS.htm">LES</A>
 <LI><A HREF="LGS.htm">LFS</A>
@@ -46,7 +47,7 @@ Note that the following interrupt-related instructions are different; all
 are capable of transferring control to another segment, but the use of
 segmentation is not apparent to the applications programmer.
 <P>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="INT.htm">INT n</A>
 <LI><A HREF="INT.htm">INTO</A>
 <LI><A HREF="BOUND.htm">BOUND</A>

--- a/s04_02.htm
+++ b/s04_02.htm
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 <HTML LANG="EN">
 <HEAD>
-<TITLE>80386 Programmer's Reference Manual -- Section 4.2</TITLE>
+  <TITLE>80386 Programmer's Reference Manual -- Section 4.2</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c04.htm">
@@ -13,10 +14,10 @@ Chapter 4 -- Systems Architecture</A><BR>
 <P>
 <H1>4.2  Systems Instructions</H1>
 Systems instructions deal with such functions as:
-<OL>
+<OL CLASS="SHORTCUTS">
 <LI> Verification of pointer parameters (refer to
 <A HREF="c06.htm">Chapter 6</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="ARPL.htm">ARPL> -- Adjust RPL</A>
 <LI><A HREF="LAR.htm">LAR -- Load Access Rights</A>
 <LI><A HREF="LSL.htm">LSL -- Load Segment Limit</A>
@@ -26,7 +27,7 @@ Systems instructions deal with such functions as:
 <P>
 <LI> Addressing descriptor tables (refer to
 <A HREF="c05.htm">Chapter 5</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="LLDT.htm">LLDT -- Load LDT Register</A>
 <LI><A HREF="SLDT.htm">SLDT -- Store LDT Register</A>
 <LI><A HREF="LGDT.htm">LGDT -- Load GDT Register</A>
@@ -35,14 +36,14 @@ Systems instructions deal with such functions as:
 <P>
 <LI> Multitasking (refer to
 <A HREF="c07.htm">Chapter 7</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="LTR.htm">LTR -- Load Task Register</A>
 <LI><A HREF="STR.htm">STR -- Store Task Register</A>
 </UL>
 <P>
 <LI> Coprocessing and Multiprocessing (refer to
 <A HREF="c11.htm">Chapter 11</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="CLTS.htm">CLTS -- Clear Task-Switched Flag</A>
 <LI>ESC -- Escape instructions
 <LI><A HREF="WAIT.htm">WAIT -- Wait until Coprocessor not Busy</A>
@@ -51,7 +52,7 @@ Systems instructions deal with such functions as:
 <P>
 <LI> Input and Output (refer to
 <A HREF="c08.htm">Chapter 8</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="IN.htm">IN -- Input</A>
 <LI><A HREF="OUT.htm">OUT -- Output</A>
 <LI><A HREF="INS.htm">INS -- Input String</A>
@@ -60,7 +61,7 @@ Systems instructions deal with such functions as:
 <P>
 <LI> Interrupt control (refer to
 <A HREF="c09.htm">Chapter 9</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="CLI.htm">CLI -- Clear Interrupt-Enable Flag</A>
 <LI><A HREF="STI.htm">STI -- Set Interrupt-Enable Flag</A>
 <LI><A HREF="LGDT.htm">LIDT -- Load IDT Register</A>
@@ -69,18 +70,18 @@ Systems instructions deal with such functions as:
 <P>
 <LI> Debugging (refer to
 <A HREF="c12.htm">Chapter 12</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="MOVRS.htm">MOV -- Move to and from debug registers</A>
 </UL>
 <P>
 <LI> TLB testing (refer to
 <A HREF="c10.htm">Chapter 10</A>):
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="MOVRS.htm">MOV -- Move to and from test registers</A>
 </UL>
 <P>
 <LI> System Control:
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="SMSW.htm">SMSW -- Set MSW</A>
 <LI><A HREF="LMSW.htm">LMSW -- Load MSW</A>
 <LI><A HREF="HLT.htm">HLT -- Halt Processor</A>

--- a/s06_03.htm
+++ b/s06_03.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 6.3</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c06.htm">
@@ -921,7 +922,7 @@ The instructions that affect system data structures can only be executed
 when CPL is zero. If the CPU encounters one of these instructions when CPL
 is greater than zero, it signals a general protection exception. These
 instructions include:
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI><A HREF="CLTS.htm">CLTS -- Clear Task-Switched Flag</A>
 <LI><A HREF="HLT.htm">HLT -- Halt Processor</A>
 <LI><A HREF="LGDT.htm">LGDT -- Load GDL Register</A>

--- a/s14_02.htm
+++ b/s14_02.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 14.2</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c14.htm">
@@ -36,7 +37,7 @@ advantage of the new applications-oriented instructions added to the
 architecture by the introduction of the 80186/80188, 80286 and 80386:
 <UL>
 <LI> New instructions introduced by 80186/80188 and 80286.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="PUSH.htm">PUSH</A> immediate data
 <LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and
 <A HREF="POPA.htm">POPA</A>)

--- a/s15_01.htm
+++ b/s15_01.htm
@@ -2,6 +2,7 @@
 <HTML LANG="EN">
 <HEAD>
 <TITLE>80386 Programmer's Reference Manual -- Section 15.1</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <B>up:</B> <A HREF="c15.htm">
@@ -39,7 +40,7 @@ applications-oriented instructions added to the architecture by the
 introduction of the 80186/80188, 80286 and 80386:
 <UL>
 <LI> New instructions introduced by 80186/80188 and 80286.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="PUSH.htm">PUSH</A> immediate data
 <LI> Push all and pop all (<A HREF="PUSHA.htm">PUSHA</A> and
 <A HREF="POPA.htm">POPA</A>)
@@ -51,7 +52,7 @@ introduction of the 80186/80188, 80286 and 80386:
 <LI> <A HREF="BOUND.htm">BOUND</A>
 </UL>
 <LI> New instructions introduced by 80386.
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="LGS.htm">LSS</A>,
 <A HREF="LGS.htm">LFS</A>,
 <A HREF="LGS.htm">LGS</A> instructions

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+.shortcuts li a {
+ min-height: 24px;
+ line-height: 24px;
+}
+
+p.shortcuts {
+ font-size: 1.2x;
+ padding: 14px;
+ min-height: 24px;
+ line-height: 24px;
+}

--- a/toc.htm
+++ b/toc.htm
@@ -1,20 +1,22 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 <HTML LANG="EN">
 <HEAD>
-<TITLE>80386 Programmer's Reference Manual -- Table of Contents</TITLE>
+<TITLE>80386 Programmer's Reference Manual -- Table of
+  Contents</TITLE>
+<LINK REL="STYLESHEET" TYPE="TEXT/CSS" HREF="style.css" />
 </HEAD>
 <BODY STYLE="width:80ch">
 <H1>Intel 80386 Reference Programmer's Manual<BR>
 Table of Contents</H2>
 <H3><A HREF="c01.htm">Chapter 1 -- Introduction to the 80386</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s01_01.htm">1.1 Organization of This Manual</A>
 <LI> <A HREF="s01_02.htm">1.2 Related Literature</A>
 <LI> <A HREF="s01_03.htm">1.3  Notational Conventions</A>
 </UL>
 <H2><A HREF="PI.htm">Part I Applications Programming</A></H2>
 <H3><A HREF="c02.htm">Chapter 2 -- Basic Programming Model</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s02_01.htm">2.1 Memory Organization and Segmentation</A><BR>
 <LI> <A HREF="s02_02.htm">2.2 Data Types</A><BR>
 <LI> <A HREF="s02_03.htm">2.3 Registers</A><BR>
@@ -23,7 +25,7 @@ Table of Contents</H2>
 <LI> <A HREF="s02_06.htm">2.6  Interrupts and Exceptions</A>
 </UL>
 <H3><A HREF="c03.htm">Chapter 3 -- Applications Instruction Set</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s03_01.htm">3.1 Data Movement Instructions</A><BR>
 <LI> <A HREF="s03_02.htm">3.2 Binary Arithmetic Instructions</A><BR>
 <LI> <A HREF="s03_03.htm">3.3 Decimal Arithmetic Instructions</A><BR>
@@ -38,18 +40,18 @@ Table of Contents</H2>
 </UL>
 <H2><A HREF="PII.htm">Part II Systems Programming</A></H2>
 <H3><A HREF="c04.htm">Chapter 4 -- Systems Architecture</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s04_01.htm">4.1 Systems Registers</A><BR>
 <LI> <A HREF="s04_02.htm">4.2  Systems Instructions</A>
 </UL>
 <H3> <A HREF="c05.htm">Chapter 5 -- Memory Management</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s05_01.htm">5.1 Segment Translation</A><BR>
 <LI> <A HREF="s05_02.htm">5.2 Page Translation</A><BR>
 <LI><A HREF="s05_03.htm">5.3  Combining Segment and Page Translation</A>
 </UL>
 <H3><A HREF="c06.htm">Chapter 6 -- Protection</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s06_01.htm">6.1 Why Protection?</A><BR>
 <LI> <A HREF="s06_02.htm">6.2 Overview of 80386 Protection Mechanisms</A><BR>
 <LI> <A HREF="s06_03.htm">6.3 Segment-Level Protection</A><BR>
@@ -57,7 +59,7 @@ Table of Contents</H2>
 <LI> <A HREF="s06_05.htm">6.5  Combining Page and Segment Protection</A>
 </UL>
 <H3> <A HREF="c07.htm">Chapter 7 -- Multitasking</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s07_01.htm">7.1 Task State Segment</A><BR>
 <LI> <A HREF="s07_02.htm">7.2 TSS Descriptor</A><BR>
 <LI> <A HREF="s07_03.htm">7.3 Task Register</A><BR>
@@ -67,13 +69,13 @@ Table of Contents</H2>
 <LI> <A HREF="s07_07.htm">7.7  Task Address Space</A>
 </UL>
 <H3><A HREF="c08.htm">Chapter 8 -- Input/Output</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s08_01.htm">8.1 I/O Addressing</A><BR>
 <LI> <A HREF="s08_02.htm">8.2 I/O Instructions</A><BR>
 <LI> <A HREF="s08_03.htm">8.3  Protection and I/O</A>
 </UL>
 <H3><A HREF="c09.htm">Chapter 9 -- Exceptions and Interrupts</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s09_01.htm">9.1 Identifying Interrupts</A><BR>
 <LI> <A HREF="s09_02.htm">9.2 Enabling and Disabling Interrupts</A><BR>
 <LI> <A HREF="s09_03.htm">9.3 Priority Among Simultaneous Interrupts and Exceptions</A><BR>
@@ -86,7 +88,7 @@ Table of Contents</H2>
 <LI> <A HREF="s09_10.htm">9.10  Error Code Summary</A>
 </UL>
 <H3><A HREF="c10.htm">Chapter 10 -- Initialization</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s10_01.htm">10.1 Processor State After Reset</A><BR>
 <LI> <A HREF="s10_02.htm">10.2 Software Initialization for Real-Address Mode</A><BR>
 <LI> <A HREF="s10_03.htm">10.3 Switching to Protected Mode</A><BR>
@@ -95,25 +97,25 @@ Table of Contents</H2>
 <LI> <A HREF="s10_06.htm">10.6  TLB Testing</A>
 </UL>
 <H3><A HREF="c11.htm">Chapter 11 -- Coprocessing and Multiprocessing</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s11_01.htm">11.1 Coprocessing</A><BR>
 <LI> <A HREF="s11_02.htm">11.2  General Multiprocessing</A>
 </UL>
 <H3><A HREF="c12.htm">Chapter 12 -- Debugging</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s12_01.htm">12.1 Debugging Features of the Architecture</A><BR>
 <LI> <A HREF="s12_02.htm">12.2 Debug Registers</A><BR>
 <LI> <A HREF="s12_03.htm">12.3  Debug Exceptions</A>
 </UL>
 <H2><A HREF="PIII.htm">Part III Compatibility</A></H2>
 <H3><A HREF="c13.htm">Chapter 13 -- Executing 80286 Protected-Mode Code</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s13_01.htm">13.1 80286 Code Executes as a Subset of the 80386</A>
 <LI> <A HREF="s13_02.htm">13.2 Two ways to Execute 80286 Tasks</A><BR>
 <LI> <A HREF="s13_03.htm">13.3  Differences From 80286</A>
 </UL>
 <H3><A HREF="c14.htm">Chapter 14 -- 80386 Real-Address Mode</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s14_01.htm">14.1 Physical Address Formation</A><BR>
 <LI> <A HREF="s14_02.htm">14.2 Registers and Instructions</A><BR>
 <LI> <A HREF="s14_03.htm">14.3 Interrupt and Exception Handling</A><BR>
@@ -124,7 +126,7 @@ Table of Contents</H2>
 <LI> <A HREF="s14_08.htm">14.8  Differences From 80286 Real-Address Mode</A>
 </UL>
 <H3><A HREF="c15.htm">Chapter 15 -- Virtual 8086 Mode</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s15_01.htm">15.1 Executing 8086 Code</A><BR>
 <LI> <A HREF="s15_02.htm">15.2 Structure of a V86 Task</A><BR>
 <LI> <A HREF="s15_03.htm">15.3 Entering and Leaving V86 Mode</A><BR>
@@ -134,7 +136,7 @@ Table of Contents</H2>
 <LI> <A HREF="s15_07.htm">15.7  Differences From 80286 Real-Address Mode</A>
 </UL>
 <H3><A HREF="c16.htm">Chapter 16 -- Mixing 16-Bit and 32 Bit Code</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s16_01.htm">16.1 How the 80386 Implements 16-Bit and 32-Bit Features</A><BR>
 <LI> <A HREF="s16_02.htm">16.2 Mixing 32-Bit and 16-Bit Operations</A><BR>
 <LI>
@@ -144,12 +146,12 @@ Table of Contents</H2>
 </UL>
 <H2><A HREF="PIV.htm">Part IV Instructions Set</A></H2>
 <H3><A HREF="c17.htm">Chapter 17 -- 80386 Instruction Set</A></H3>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI> <A HREF="s17_01.htm">17.1  Operand-Size and Address-Size Attributes</A>
 <LI> <A HREF="s17_02.htm">17.2 Instruction Format</A>
 </UL>
 <H2><A HREF="app.htm">Appendices</A></H2>
-<UL>
+<UL CLASS="SHORTCUTS">
 <LI>
 <A HREF="appa.htm">Appendix A -- Opcode Map</A><BR>
 <LI>


### PR DESCRIPTION
An accessibility checker caught a level AA compliance issue with these pages - the minimum height of a link must be 24 px.

https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html

Address this issue by making a css and adding a class to the appropriate lists.